### PR TITLE
Use more precise terminology re library versions

### DIFF
--- a/api/server/advisory/client_connect.go
+++ b/api/server/advisory/client_connect.go
@@ -37,9 +37,7 @@ func init() {
           Name: {{ .Client.Name }}
 {{- end }}
        Account: {{ .Client.Account }}
-{{- if .Client.Lang }}
-      Language: {{ .Client.Lang }} {{ .Client.Version }}
-{{- end }}
+       Library: {{ with .Client.Version }}version={{ . }} {{ end }}{{ with .Client.Lang }}language={{ . }}{{ else }}language-unknown{{ end }}
 {{- if .Client.Host }}
           Host: {{ .Client.Host }}
 {{- end }}`)

--- a/api/server/advisory/client_connect.go
+++ b/api/server/advisory/client_connect.go
@@ -37,7 +37,7 @@ func init() {
           Name: {{ .Client.Name }}
 {{- end }}
        Account: {{ .Client.Account }}
-       Library: {{ with .Client.Version }}version={{ . }} {{ end }}{{ with .Client.Lang }}language={{ . }}{{ else }}language-unknown{{ end }}
+       Library Version: {{ .Client.Version }}  Language: {{ with .Client.Lang }}{{ . }}{{ else }}Unknown{{ end }}
 {{- if .Client.Host }}
           Host: {{ .Client.Host }}
 {{- end }}`)

--- a/api/server/advisory/client_disconnect.go
+++ b/api/server/advisory/client_disconnect.go
@@ -43,9 +43,7 @@ func init() {
           Name: {{ .Client.Name }}
 {{- end }}
        Account: {{ .Client.Account }}
-{{- if .Client.Lang }}
-      Language: {{ .Client.Lang }} {{ .Client.Version }}
-{{- end }}
+       Library: {{ with .Client.Version }}version={{ . }} {{ end }}{{ with .Client.Lang }}language={{ . }}{{ else }}language-unknown{{ end }}
 {{- if .Client.Host }}
           Host: {{ .Client.Host }}
 {{- end }}

--- a/api/server/advisory/client_disconnect.go
+++ b/api/server/advisory/client_disconnect.go
@@ -43,7 +43,7 @@ func init() {
           Name: {{ .Client.Name }}
 {{- end }}
        Account: {{ .Client.Account }}
-       Library: {{ with .Client.Version }}version={{ . }} {{ end }}{{ with .Client.Lang }}language={{ . }}{{ else }}language-unknown{{ end }}
+       Library Version: {{ .Client.Version }}  Language: {{ with .Client.Lang }}{{ . }}{{ else }}Unknown{{ end }}
 {{- if .Client.Host }}
           Host: {{ .Client.Host }}
 {{- end }}


### PR DESCRIPTION
On reading the old output, I saw `Language: go 1.11.0` which I read as meaning "version 1.11.0 of Golang".  This is not what the version field is supposed to mean: it's a version of the library.

This is attempt 1 at rephrasing the Extended Text output format to categorise a little differently.  I suspect that this particular wording won't be accepted and that's fine — this highlights the two bits of code which should change and folks can debate the better phrasing.

With this particular incarnation of a fix, I now see:

    Library: version=1.11.0 language=go