### PR TITLE
Fix call to sort.Slice() that uses wrong slice

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -375,7 +375,7 @@ func (m *Manager) Consumers(stream string) (consumers []*Consumer, err error) {
 	}
 
 	sort.Slice(cinfo, func(i int, j int) bool {
-		return resp.Consumers[i].Name < resp.Consumers[j].Name
+		return cinfo[i].Name < cinfo[j].Name
 	})
 
 	for _, c := range cinfo {


### PR DESCRIPTION
This should fix this:

```
$ nats con report bigtest
panic: runtime error: index out of range [1250] with length 16

goroutine 1 [running]:
github.com/nats-io/jsm%2ego.(*Manager).Consumers.func2(0x0, 0x4e2, 0x16665c0)
	/Users/rip/go/pkg/mod/github.com/nats-io/jsm.go@v0.0.24/manager.go:363 +0x87
sort.medianOfThree_func(0xc000315848, 0xc000368ae0, 0x0, 0x4e2, 0x9c4)
	/usr/local/go/src/sort/zfuncversion.go:53 +0x3e
sort.doPivot_func(0xc000315848, 0xc000368ae0, 0x0, 0x2710, 0x2710, 0x5481800)
	/usr/local/go/src/sort/zfuncversion.go:76 +0x4fc
sort.quickSort_func(0xc000315848, 0xc000368ae0, 0x0, 0x2710, 0x1c)
	/usr/local/go/src/sort/zfuncversion.go:143 +0x97
sort.Slice(0x16167a0, 0xc0000a34d0, 0xc000315848)
	/usr/local/go/src/sort/slice.go:20 +0xe8
github.com/nats-io/jsm%2ego.(*Manager).Consumers(0xc00014eae0, 0xc000402eb0, 0x7, 0xc000064d80, 0x0, 0xc00031f8f8, 0x100e138, 0x90)
	/Users/rip/go/pkg/mod/github.com/nats-io/jsm.go@v0.0.24/manager.go:362 +0x24c
github.com/nats-io/jsm%2ego.(*Stream).EachConsumer(0xc00039ef40, 0xc000315ab8, 0xc00039a4e0, 0x2)
	/Users/rip/go/pkg/mod/github.com/nats-io/jsm.go@v0.0.24/streams.go:425 +0x47
main.(*consumerCmd).reportAction(0xc0001bf8c0, 0xc0000d0360, 0x0, 0x0)
	/Users/rip/go/src/github.com/nats-io/natscli/nats/consumer_command.go:1024 +0x3ce
gopkg.in/alecthomas/kingpin%2ev2.(*actionMixin).applyActions(0xc0001a2c18, 0xc0000d0360, 0x0, 0x0)
	/Users/rip/go/pkg/mod/gopkg.in/alecthomas/kingpin.v2@v2.2.6/actions.go:28 +0x6d
gopkg.in/alecthomas/kingpin%2ev2.(*Application).applyActions(0xc000186690, 0xc0000d0360, 0x0, 0x0)
	/Users/rip/go/pkg/mod/gopkg.in/alecthomas/kingpin.v2@v2.2.6/app.go:557 +0xdf
gopkg.in/alecthomas/kingpin%2ev2.(*Application).execute(0xc000186690, 0xc0000d0360, 0xc000368000, 0x2, 0x2, 0x0, 0x0, 0x0, 0x1648400)
	/Users/rip/go/pkg/mod/gopkg.in/alecthomas/kingpin.v2@v2.2.6/app.go:390 +0x95
gopkg.in/alecthomas/kingpin%2ev2.(*Application).Parse(0xc000186690, 0xc0000a8050, 0x3, 0x3, 0x1, 0xc0000a6a20, 0x0, 0x1)
	/Users/rip/go/pkg/mod/gopkg.in/alecthomas/kingpin.v2@v2.2.6/app.go:222 +0x228
main.main()
	/Users/rip/go/src/github.com/nats-io/natscli/nats/main.go:113 +0x1905
```