### PR TITLE
clearer API around sealing streams

### DIFF
--- a/api/schemas_generated.go
+++ b/api/schemas_generated.go
@@ -1,4 +1,4 @@
-// auto generated 2021-09-30 11:48:22.063282 +0200 CEST m=+0.025784938
+// auto generated 2021-09-30 11:59:27.369289 +0200 CEST m=+0.026400565
 
 package api
 

--- a/schema_source/jetstream/api/v1/definitions.json
+++ b/schema_source/jetstream/api/v1/definitions.json
@@ -820,7 +820,7 @@
         },
         "sealed": {
           "type": "boolean",
-          "description": "Sealed streams do not allow messages to be deleted via limits or API, sealed streams can not be unsealed via configuration update"
+          "description": "Sealed streams do not allow messages to be deleted via limits or API, sealed streams can not be unsealed via configuration update. Can only be set on already created streams via the Update API"
         }
       }
     },

--- a/streams.go
+++ b/streams.go
@@ -365,14 +365,6 @@ func Sources(streams ...*api.StreamSource) StreamOption {
 	}
 }
 
-// Sealed seals a stream so that messages can not be deleted by API or limits, sealed streams can not be unsealed
-func Sealed() StreamOption {
-	return func(o *api.StreamConfig) error {
-		o.Sealed = true
-		return nil
-	}
-}
-
 // PageContents creates a StreamPager used to traverse the contents of the stream,
 // Close() should be called to dispose of the background consumer and resources
 func (s *Stream) PageContents(opts ...PagerOption) (*StreamPager, error) {
@@ -514,6 +506,14 @@ func (s *Stream) Delete() error {
 	}
 
 	return nil
+}
+
+// Seal updates a stream so that messages can not be added or removed using the API and limits will not be processed - messages will never age out.
+// A sealed stream can not be unsealed.
+func (s *Stream) Seal() error {
+	cfg := s.Configuration()
+	cfg.Sealed = true
+	return s.UpdateConfiguration(cfg)
 }
 
 // Purge deletes messages from the Stream, an optional JSApiStreamPurgeRequest can be supplied to limit the purge to a subset of messages

--- a/streams_test.go
+++ b/streams_test.go
@@ -821,13 +821,17 @@ func TestStreamSealed(t *testing.T) {
 	_, err = nc.Request("test", []byte("1"), time.Second)
 	checkErr(t, err, "publish failed")
 
-	err = s.UpdateConfiguration(s.Configuration(), jsm.Sealed())
+	err = s.Seal()
 	checkErr(t, err, "seal update failed")
 
 	nfo, err := s.LatestInformation()
 	checkErr(t, err, "info failed")
 
 	if !nfo.Config.Sealed {
+		t.Fatalf("expected a sealed stream")
+	}
+
+	if !s.Sealed() {
 		t.Fatalf("expected a sealed stream")
 	}
 


### PR DESCRIPTION
Signed-off-by: R.I.Pienaar <rip@devco.net>