### PR TITLE
Enable stream report to work, even if error 10004 is set

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -102,7 +102,7 @@ func (m *Manager) jsonRequest(subj string, req interface{}, response interface{}
 	msg, err := m.request(m.apiSubject(subj), body)
 	if err != nil {
 		// error, unless the error code for incomplete is set
-		if err, ok := err.(api.ApiError); !ok || err.ErrCode != 10004 {
+		if !IsNatsError(err, 10004) {
 			return err
 		}
 	}
@@ -201,7 +201,7 @@ func (m *Manager) iterableRequest(subj string, req apiIterableRequest, response 
 
 		err = m.jsonRequest(subj, req, response)
 		if err != nil {
-			if err, ok := err.(api.ApiError); !ok || err.ErrCode != 10004 {
+			if !IsNatsError(err, 10004) {
 				return err
 			}
 			errLast = err
@@ -351,7 +351,7 @@ func (m *Manager) EachStreamTemplate(cb func(*StreamTemplate)) (err error) {
 func (m *Manager) EachStream(cb func(*Stream)) (err error) {
 	streams, err := m.Streams()
 	if err != nil {
-		if err, ok := err.(api.ApiError); !ok || err.ErrCode != 10004 {
+		if !IsNatsError(err, 10004) {
 			return err
 		}
 	}

--- a/streams.go
+++ b/streams.go
@@ -455,7 +455,7 @@ func (s *Stream) ConsumerNames() (names []string, err error) {
 func (s *Stream) EachConsumer(cb func(consumer *Consumer)) error {
 	consumers, err := s.mgr.Consumers(s.Name())
 	if err != nil {
-		if err, ok := err.(api.ApiError); !ok || err.ErrCode != 10004 {
+		if !IsNatsError(err, 10004) {
 			return err
 		}
 	}

--- a/streams.go
+++ b/streams.go
@@ -455,14 +455,16 @@ func (s *Stream) ConsumerNames() (names []string, err error) {
 func (s *Stream) EachConsumer(cb func(consumer *Consumer)) error {
 	consumers, err := s.mgr.Consumers(s.Name())
 	if err != nil {
-		return err
+		if err, ok := err.(api.ApiError); !ok || err.ErrCode != 10004 {
+			return err
+		}
 	}
 
 	for _, c := range consumers {
 		cb(c)
 	}
 
-	return nil
+	return err
 }
 
 // LatestInformation returns the most recently fetched stream information


### PR DESCRIPTION
This PR corresponds to the [natscli](https://github.com/nats-io/natscli/pull/306) one.

The only thing I had to bypass here was the json schema check.  

These PRs are about showing the returned list of stream/cluster even when the error code is set.
The server sends this value anyways, just currently they are not displayed.
When both the PRs are applied the following 

Here pointed at a test server that threw away responses from streams/consumers that started with the name fail.
In either case nats now shows the streams AND shows the error.
```
> nats -s localhost:4222 c report drei --trace
20:27:54 >>> $JS.API.STREAM.INFO.drei


20:27:54 <<< $JS.API.STREAM.INFO.drei
{"type":"io.nats.jetstream.api.v1.stream_info_response","config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"domain":"hub","cluster":{"name":"hub","leader":"hub-server-1"}}

20:27:54 >>> $JS.API.STREAM.INFO.drei


20:27:54 <<< $JS.API.STREAM.INFO.drei
{"type":"io.nats.jetstream.api.v1.stream_info_response","config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"domain":"hub","cluster":{"name":"hub","leader":"hub-server-1"}}

20:27:54 >>> $JS.API.CONSUMER.LIST.drei
{"offset":0}

20:27:58 <<< $JS.API.CONSUMER.LIST.drei
{"type":"io.nats.jetstream.api.v1.consumer_list_response","error":{"code":503,"err_code":10004,"description":"incomplete results"},"total":1,"offset":0,"limit":256,"consumers":[{"stream_name":"drei","name":"dur","created":"2021-12-01T23:15:46.697564Z","config":{"durable_name":"dur","deliver_policy":"all","ack_policy":"explicit","ack_wait":30000000000,"max_deliver":-1,"replay_policy":"original","max_waiting":512,"max_ack_pending":20000},"delivered":{"consumer_seq":0,"stream_seq":0},"ack_floor":{"consumer_seq":0,"stream_seq":0},"num_ack_pending":0,"num_redelivered":0,"num_waiting":0,"num_pending":0,"cluster":{"name":"hub","leader":"hub-server-1"}}]}

20:27:58 >>> $JS.API.CONSUMER.INFO.drei.dur


20:27:58 <<< $JS.API.CONSUMER.INFO.drei.dur
{"type":"io.nats.jetstream.api.v1.consumer_info_response","stream_name":"drei","name":"dur","created":"2021-12-01T23:15:46.697564Z","config":{"durable_name":"dur","deliver_policy":"all","ack_policy":"explicit","ack_wait":30000000000,"max_deliver":-1,"replay_policy":"original","max_waiting":512,"max_ack_pending":20000},"delivered":{"consumer_seq":0,"stream_seq":0},"ack_floor":{"consumer_seq":0,"stream_seq":0},"num_ack_pending":0,"num_redelivered":0,"num_waiting":0,"num_pending":0,"cluster":{"name":"hub","leader":"hub-server-1"}}

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                   Consumer report for drei with 2 consumers                                   │
├──────────┬──────┬────────────┬──────────┬─────────────┬─────────────┬─────────────┬───────────┬───────────────┤
│ Consumer │ Mode │ Ack Policy │ Ack Wait │ Ack Pending │ Redelivered │ Unprocessed │ Ack Floor │ Cluster       │
├──────────┼──────┼────────────┼──────────┼─────────────┼─────────────┼─────────────┼───────────┼───────────────┤
│ dur      │ Pull │ Explicit   │ 30.00s   │ 0           │ 0           │ 0           │ 0         │ hub-server-1* │
╰──────────┴──────┴────────────┴──────────┴─────────────┴─────────────┴─────────────┴───────────┴───────────────╯

nats: error: incomplete results (10004), try --help
> nats -s localhost:4222 s report  --trace
Obtaining Stream stats

20:28:08 >>> $JS.API.STREAM.LIST
{"offset":0}

20:28:12 <<< $JS.API.STREAM.LIST
{"type":"io.nats.jetstream.api.v1.stream_list_response","error":{"code":503,"err_code":10004,"description":"incomplete results"},"total":2,"offset":0,"limit":256,"streams":[{"config":{"name":"drei","subjects":["drei"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:44.129716Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":2},"cluster":{"name":"hub","leader":"hub-server-1"}},{"config":{"name":"test","subjects":["test"],"retention":"limits","max_consumers":-1,"max_msgs":-1,"max_bytes":-1,"max_age":0,"max_msgs_per_subject":-1,"max_msg_size":-1,"discard":"old","storage":"file","num_replicas":1,"duplicate_window":120000000000,"sealed":false,"deny_delete":false,"deny_purge":false,"allow_rollup_hdrs":false},"created":"2021-12-01T21:50:15.598479Z","state":{"messages":0,"bytes":0,"first_seq":1,"first_ts":"1970-01-01T00:00:00Z","last_seq":0,"last_ts":"0001-01-01T00:00:00Z","consumer_count":0},"cluster":{"name":"hub","leader":"hub-server-3"}}]}

╭──────────────────────────────────────────────────────────────────────────────────╮
│                                  Stream Report                                   │
├────────┬─────────┬───────────┬──────────┬───────┬──────┬─────────┬───────────────┤
│ Stream │ Storage │ Consumers │ Messages │ Bytes │ Lost │ Deleted │ Replicas      │
├────────┼─────────┼───────────┼──────────┼───────┼──────┼─────────┼───────────────┤
│ drei   │ File    │ 2         │ 0        │ 0 B   │ 0    │ 0       │ hub-server-1* │
│ test   │ File    │ 0         │ 0        │ 0 B   │ 0    │ 0       │ hub-server-3* │
╰────────┴─────────┴───────────┴──────────┴───────┴──────┴─────────┴───────────────╯

nats: error: incomplete results (10004), try --help
>
```