### PR TITLE
improve handling of context urls

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -77,7 +77,7 @@ type Context struct {
 func New(name string, load bool, opts ...Option) (*Context, error) {
 	c := &Context{
 		Name:   name,
-		config: &settings{URL: nats.DefaultURL},
+		config: &settings{},
 	}
 
 	if load {
@@ -90,6 +90,10 @@ func New(name string, load bool, opts ...Option) (*Context, error) {
 	// apply supplied overrides
 	for _, opt := range opts {
 		opt(c.config)
+	}
+
+	if c.config.NSCLookup == "" && c.config.URL == "" && c.config.nscUrl == "" {
+		c.config.URL = nats.DefaultURL
 	}
 
 	return c, nil


### PR DESCRIPTION
Previously if --nsc was specified on the CLI
it would add the nsc lookup url but ALSO a server
url based on DefaultURL. And then that would win
over whatever nsc set.

Now that default is only set when no nsc or url is
given

Signed-off-by: R.I.Pienaar <rip@devco.net>