### PR TITLE
Ensure LoadOrNEw does not try to remake existing

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -146,7 +146,7 @@ func (m *Manager) LoadOrNewConsumerFromDefault(stream string, name string, templ
 	}
 
 	c, err := m.LoadConsumer(stream, name)
-	if c == nil || err != nil {
+	if IsNatsError(err, 10014) {
 		return m.NewConsumerFromDefault(stream, template, opts...)
 	}
 

--- a/streams.go
+++ b/streams.go
@@ -111,7 +111,7 @@ func (m *Manager) LoadOrNewStreamFromDefault(name string, dflt api.StreamConfig,
 		o(&dflt)
 	}
 	s, err := m.LoadStream(name)
-	if s == nil || err != nil {
+	if IsNatsError(err, 10059) {
 		return m.NewStreamFromDefault(name, dflt)
 	}
 


### PR DESCRIPTION
These 2 methods were written before we had error codes so we had
no choice but to just handle any error and try to create it.

Now we can tighten this up a bit and only specifically handle the
one error for resource not found, the rest are returned as the
original error.  This should avoid some weird conditions in code
that tries to recover from missing streams