### PR TITLE
[CHANGED] Chunk size for backup and restore

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Install deps
         shell: bash --noprofile --norc -x -eo pipefail {0}

--- a/snapshots.go
+++ b/snapshots.go
@@ -312,7 +312,7 @@ func (m *Manager) RestoreSnapshotFromDirectory(ctx context.Context, stream strin
 		dir:      dir,
 		dataFile: filepath.Join(dir, "stream.tar.s2"),
 		metaFile: filepath.Join(dir, "backup.json"),
-		chunkSz:  512 * 1024,
+		chunkSz:  64 * 1024,
 	}
 
 	for _, opt := range opts {
@@ -390,7 +390,7 @@ func (m *Manager) RestoreSnapshotFromDirectory(ctx context.Context, stream strin
 	progress.notify()
 
 	nc := m.nc
-	var chunk [512 * 1024]byte
+	var chunk [64 * 1024]byte
 	var cresp *nats.Msg
 
 	for {
@@ -464,7 +464,7 @@ func (s *Stream) SnapshotToDirectory(ctx context.Context, dir string, opts ...Sn
 		metaFile:  filepath.Join(dir, "backup.json"),
 		jsck:      false,
 		consumers: false,
-		chunkSz:   512 * 1024,
+		chunkSz:   128 * 1024,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
For snapshot (backup), we should even ideally set the chunk size
to 0 to let the server decide, but since we need it for the
progress bar, set it to 128KB to match what will be the new
default (if not set) in the server.

For restore, set it to 64KB because on NGS for instance, basic
accounts would then not be able to do any restore because the
chunk size would be too big.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>