### PR TITLE
Add schema for JSConsumerDeliveryNakAdvisory

### DIFF
--- a/api/gen.go
+++ b/api/gen.go
@@ -192,6 +192,7 @@ func main() {
 		&schema{P: "server/metric/v1/service_latency.json", St: "srvmetric.ServiceLatencyV1"},
 		&schema{P: "jetstream/advisory/v1/api_audit.json", St: "jsadvisory.JetStreamAPIAuditV1"},
 		&schema{P: "jetstream/advisory/v1/max_deliver.json", St: "jsadvisory.ConsumerDeliveryExceededAdvisoryV1"},
+		&schema{P: "jetstream/advisory/v1/nak.json", St: "jsadvisory.JSConsumerDeliveryNakAdvisoryV1"},
 		&schema{P: "jetstream/advisory/v1/terminated.json", St: "jsadvisory.JSConsumerDeliveryTerminatedAdvisoryV1"},
 		&schema{P: "jetstream/advisory/v1/stream_action.json", St: "jsadvisory.JSStreamActionAdvisoryV1"},
 		&schema{P: "jetstream/advisory/v1/consumer_action.json", St: "jsadvisory.JSConsumerActionAdvisoryV1"},

--- a/api/jetstream/advisory/nak.go
+++ b/api/jetstream/advisory/nak.go
@@ -1,0 +1,38 @@
+package advisory
+
+import (
+	"github.com/nats-io/jsm.go/api/event"
+)
+
+// JSConsumerDeliveryNakAdvisoryV1 is an advisory informing that a message was
+// naked by the consumer
+//
+// NATS Schema: io.nats.jetstream.advisory.v1.nak
+type JSConsumerDeliveryNakAdvisoryV1 struct {
+	event.NATSEvent
+
+	Stream      string `json:"stream"`
+	Consumer    string `json:"consumer"`
+	ConsumerSeq uint64 `json:"consumer_seq"`
+	StreamSeq   uint64 `json:"stream_seq"`
+	Deliveries  uint64 `json:"deliveries"`
+	Domain      string `json:"domain,omitempty"`
+}
+
+func init() {
+	err := event.RegisterTextCompactTemplate("io.nats.jetstream.advisory.v1.nak", `{{ .Time | ShortTime }} [JS Delivery NAKed] {{ .Stream }} ({{ .StreamSeq }}) > {{ .Consumer }}: {{ .Deliveries }} deliveries`)
+	if err != nil {
+		panic(err)
+	}
+
+	err = event.RegisterTextExtendedTemplate("io.nats.jetstream.advisory.v1.nak", `
+[{{ .Time | ShortTime }}] [{{ .ID }}] Delivery NAKed
+
+          Consumer: {{ .Stream }} > {{ .Consumer }}
+   Stream Sequence: {{ .StreamSeq }}
+        Deliveries: {{ .Deliveries }}
+            Domain: {{ .Domain }}`)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/api/schemas_generated.go
+++ b/api/schemas_generated.go
@@ -17,6 +17,7 @@ var schemaTypes = map[string]func() interface{}{
 	"io.nats.server.metric.v1.service_latency":                   func() interface{} { return &srvmetric.ServiceLatencyV1{} },
 	"io.nats.jetstream.advisory.v1.api_audit":                    func() interface{} { return &jsadvisory.JetStreamAPIAuditV1{} },
 	"io.nats.jetstream.advisory.v1.max_deliver":                  func() interface{} { return &jsadvisory.ConsumerDeliveryExceededAdvisoryV1{} },
+	"io.nats.jetstream.advisory.v1.nak":                          func() interface{} { return &jsadvisory.JSConsumerDeliveryNakAdvisoryV1{} },
 	"io.nats.jetstream.advisory.v1.terminated":                   func() interface{} { return &jsadvisory.JSConsumerDeliveryTerminatedAdvisoryV1{} },
 	"io.nats.jetstream.advisory.v1.stream_action":                func() interface{} { return &jsadvisory.JSStreamActionAdvisoryV1{} },
 	"io.nats.jetstream.advisory.v1.consumer_action":              func() interface{} { return &jsadvisory.JSConsumerActionAdvisoryV1{} },

--- a/schema_source/jetstream/advisory/v1/nak.json
+++ b/schema_source/jetstream/advisory/v1/nak.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nats.io/schemas/jetstream/advisory/v1/nak.json",
+  "description": "Advisory published when a message was naked using a AckNak acknowledgement",
+  "title": "io.nats.jetstream.advisory.v1.nak",
+  "type":"object",
+  "required":[
+    "type",
+    "id",
+    "timestamp",
+    "stream",
+    "consumer",
+    "consumer_seq",
+    "stream_seq",
+    "deliveries"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "io.nats.jetstream.advisory.v1.nak"
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique correlation ID for this event"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "The time this event was created in RFC3339 format"
+    },
+    "stream": {
+      "type": "string",
+      "description": "The name of the stream where the message is stored"
+    },
+    "consumer": {
+      "type": "string",
+      "description": "The name of the consumer where the message was naked"
+    },
+    "consumer_seq": {
+      "type": "string",
+      "minimum": 1,
+      "description": "The sequence of the message in the consumer that was naked"
+    },
+    "stream_seq": {
+      "type": "string",
+      "minimum": 1,
+      "description": "The sequence of the message in the stream that was naked"
+    },
+    "deliveries": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The number of deliveries that were attempted"
+    },
+     "domain": {
+      "type": "string",
+      "minimum": 1,
+      "description": "The domain of the JetStreamServer"
+    }
+  }
+}

--- a/schemas/jetstream/advisory/v1/nak.json
+++ b/schemas/jetstream/advisory/v1/nak.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nats.io/schemas/jetstream/advisory/v1/nak.json",
+  "description": "Advisory published when a message was naked using a AckNak acknowledgement",
+  "title": "io.nats.jetstream.advisory.v1.nak",
+  "type": "object",
+  "required": [
+    "type",
+    "id",
+    "timestamp",
+    "stream",
+    "consumer",
+    "consumer_seq",
+    "stream_seq",
+    "deliveries"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "io.nats.jetstream.advisory.v1.nak"
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique correlation ID for this event"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "The time this event was created in RFC3339 format"
+    },
+    "stream": {
+      "type": "string",
+      "description": "The name of the stream where the message is stored"
+    },
+    "consumer": {
+      "type": "string",
+      "description": "The name of the consumer where the message was naked"
+    },
+    "consumer_seq": {
+      "type": "string",
+      "minimum": 1,
+      "description": "The sequence of the message in the consumer that was naked"
+    },
+    "stream_seq": {
+      "type": "string",
+      "minimum": 1,
+      "description": "The sequence of the message in the stream that was naked"
+    },
+    "deliveries": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "The number of deliveries that were attempted"
+    },
+    "domain": {
+      "type": "string",
+      "minimum": 1,
+      "description": "The domain of the JetStreamServer"
+    }
+  }
+}


### PR DESCRIPTION
This is a follow up to:
+ Issue: https://github.com/nats-io/nats-server/issues/3072
+ Implementation PR: https://github.com/nats-io/nats-server/pull/3074
+ Documentation PR: https://github.com/nats-io/nats.docs/pull/416

I put the domain only in the ExtendedTemplate as it might be too long for the compact version. If you wish, I will put it also in the CompactTemplate.