### PR TITLE
Use stderr for nsc invoke failed

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -393,7 +393,7 @@ func (c *Context) resolveNscLookup() error {
 	cmd := exec.Command(path, "generate", "profile", c.config.NSCLookup)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("nsc invoke failed: %s", err)
+		return fmt.Errorf("nsc invoke failed: %s", string(out))
 	}
 
 	type nscCreds struct {


### PR DESCRIPTION
Use output since stderr is combined. The `err` value only states `exit status 1` for the process exit code.