### PR TITLE
[fix] Prevent saving when multiple credentials exist

### DIFF
--- a/natscontext/context_test.go
+++ b/natscontext/context_test.go
@@ -70,6 +70,16 @@ func TestContext(t *testing.T) {
 		t.Fatalf("expected ngs got %s", config.ServerURL())
 	}
 
+	// Disallow multiple credential types
+	config, err = natscontext.New("multi_creds", true)
+	if err != nil {
+		t.Fatalf("error loading context: %s", err)
+	}
+	err = config.Save("multi_creds")
+	if err == nil {
+		t.Fatalf("expected error saving context with multiple credentials, received none")
+	}
+
 	// support missing config/context
 	os.Setenv("XDG_CONFIG_HOME", "/nonexisting")
 	config, err = natscontext.New("", true)

--- a/natscontext/testdata/nats/context/multi_creds.json
+++ b/natscontext/testdata/nats/context/multi_creds.json
@@ -1,0 +1,18 @@
+{
+  "description": "",
+  "url": "demo.nats.io",
+  "token": "foo",
+  "user": "foo",
+  "password": "foo",
+  "creds": "foo",
+  "nkey": "foo",
+  "cert": "",
+  "key": "",
+  "ca": "",
+  "nsc": "",
+  "jetstream_domain": "",
+  "jetstream_api_prefix": "",
+  "jetstream_event_prefix": "",
+  "inbox_prefix": "",
+  "user_jwt": ""
+}


### PR DESCRIPTION
Ran into this debugging/interacting with users, currently you can save multiple types of credentials in a context, which can lead to some pretty confusing behavior when trying to connect.

Still up in the air whether this should live here or in `nats context
validate`, and open to opinions.
