### PR TITLE
remove validation where username, password and token are set

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -480,18 +480,26 @@ func (c *Context) MarshalJSON() ([]byte, error) {
 	return json.MarshalIndent(c.config, "", "  ")
 }
 
+func (c *Context) Validate() error {
+	if !validName(c.Name) {
+		return fmt.Errorf("invalid context name %q", c.Name)
+	}
+
+	if numCreds(c) > 1 {
+		return errors.New("too many types of credentials. Choose only one from 'user/token', 'creds', 'nkey', 'nsc'")
+	}
+
+	return nil
+}
+
 // Save saves the current context to name
 func (c *Context) Save(name string) error {
 	if name != "" {
 		c.Name = name
 	}
 
-	if !validName(c.Name) {
-		return fmt.Errorf("invalid context name %q", c.Name)
-	}
-
-	if numCreds(c) > 1 {
-		return errors.New("too many types of credentials. Choose only one from 'user/password/token', 'creds', 'nkey', 'nsc'")
+	if err := c.Validate(); err != nil {
+		return err
 	}
 
 	parent, err := parentDir()

--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -437,12 +437,12 @@ func numCreds(c *Context) int {
 		c.config.User,
 		c.config.Creds,
 		c.config.NKey,
-		c.config.Token,
 		c.config.NSCLookup,
 	}
 
-	for _, c := range creds {
+	for k, c := range creds {
 		if c != "" {
+			fmt.Println(k, c)
 			i++
 		}
 	}
@@ -492,7 +492,7 @@ func (c *Context) Save(name string) error {
 	}
 
 	if numCreds(c) > 1 {
-		return errors.New("too many types of credentials. Choose only one from 'user/password', 'creds', 'nkey', 'token', 'nsc'")
+		return errors.New("too many types of credentials. Choose only one from 'user/password/token', 'creds', 'nkey', 'nsc'")
 	}
 
 	parent, err := parentDir()

--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -440,9 +440,8 @@ func numCreds(c *Context) int {
 		c.config.NSCLookup,
 	}
 
-	for k, c := range creds {
+	for _, c := range creds {
 		if c != "" {
-			fmt.Println(k, c)
 			i++
 		}
 	}

--- a/natscontext/context_test.go
+++ b/natscontext/context_test.go
@@ -80,6 +80,16 @@ func TestContext(t *testing.T) {
 		t.Fatalf("expected error saving context with multiple credentials, received none")
 	}
 
+	// Make sure username, password, and token can coexist
+	config, err = natscontext.New("user_pass_token_creds", true)
+	if err != nil {
+		t.Fatalf("error loading context: %s", err)
+	}
+	err = config.Save("user_pass_token_creds")
+	if err != nil {
+		t.Fatalf("expected no error when saving a context with username and password")
+	}
+
 	// support missing config/context
 	os.Setenv("XDG_CONFIG_HOME", "/nonexisting")
 	config, err = natscontext.New("", true)

--- a/natscontext/testdata/nats/context/user_pass_token_creds.json
+++ b/natscontext/testdata/nats/context/user_pass_token_creds.json
@@ -1,0 +1,20 @@
+{
+  "description": "",
+  "url": "demo.nats.io",
+  "socks_proxy": "",
+  "token": "foo",
+  "user": "foo",
+  "password": "foo",
+  "creds": "",
+  "nkey": "",
+  "cert": "",
+  "key": "",
+  "ca": "",
+  "nsc": "",
+  "jetstream_domain": "",
+  "jetstream_api_prefix": "",
+  "jetstream_event_prefix": "",
+  "inbox_prefix": "",
+  "user_jwt": "",
+  "color_scheme": ""
+}


### PR DESCRIPTION
NATS CLI currently uses the `--username` flag to create both the username and token fields in the nats context, leading to a validation error. In order to not break backward compatibility with NATS cli, I've opted to remove `token` from the list of validations, and included a regression test.
