### PR TITLE
Add `observer` to peer info

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -66,9 +66,10 @@ type ClusterInfo struct {
 // PeerInfo shows information about all the peers in the cluster that
 // are supporting the stream or consumer.
 type PeerInfo struct {
-	Name    string        `json:"name" yaml:"name"`
-	Current bool          `json:"current" yaml:"current"`
-	Offline bool          `json:"offline,omitempty" yaml:"offline"`
-	Active  time.Duration `json:"active" yaml:"active"`
-	Lag     uint64        `json:"lag,omitempty" yaml:"lag"`
+	Name     string        `json:"name" yaml:"name"`
+	Current  bool          `json:"current" yaml:"current"`
+	Observer bool          `json:"observer,omitempty" yaml:"observer"`
+	Offline  bool          `json:"offline,omitempty" yaml:"offline"`
+	Active   time.Duration `json:"active" yaml:"active"`
+	Lag      uint64        `json:"lag,omitempty" yaml:"lag"`
 }

--- a/schema_source/jetstream/api/v1/definitions.json
+++ b/schema_source/jetstream/api/v1/definitions.json
@@ -174,6 +174,11 @@
           "type": "boolean",
           "default": false
         },
+        "observer": {
+          "description": "Indicates if the server is running as an observer only",
+          "type": "boolean",
+          "default": false
+        },
         "active": {
           "description": "Nanoseconds since this peer was last seen",
           "type": "number"

--- a/schemas/jetstream/advisory/v1/consumer_leader_elected.json
+++ b/schemas/jetstream/advisory/v1/consumer_leader_elected.json
@@ -57,6 +57,11 @@
           "type": "boolean",
           "default": false
         },
+        "observer": {
+          "description": "Indicates if the server is running as an observer only",
+          "type": "boolean",
+          "default": false
+        },
         "active": {
           "description": "Nanoseconds since this peer was last seen",
           "type": "number"

--- a/schemas/jetstream/advisory/v1/consumer_quorum_lost.json
+++ b/schemas/jetstream/advisory/v1/consumer_quorum_lost.json
@@ -52,6 +52,11 @@
           "type": "boolean",
           "default": false
         },
+        "observer": {
+          "description": "Indicates if the server is running as an observer only",
+          "type": "boolean",
+          "default": false
+        },
         "active": {
           "description": "Nanoseconds since this peer was last seen",
           "type": "number"

--- a/schemas/jetstream/advisory/v1/stream_leader_elected.json
+++ b/schemas/jetstream/advisory/v1/stream_leader_elected.json
@@ -52,6 +52,11 @@
           "type": "boolean",
           "default": false
         },
+        "observer": {
+          "description": "Indicates if the server is running as an observer only",
+          "type": "boolean",
+          "default": false
+        },
         "active": {
           "description": "Nanoseconds since this peer was last seen",
           "type": "number"

--- a/schemas/jetstream/advisory/v1/stream_quorum_lost.json
+++ b/schemas/jetstream/advisory/v1/stream_quorum_lost.json
@@ -47,6 +47,11 @@
           "type": "boolean",
           "default": false
         },
+        "observer": {
+          "description": "Indicates if the server is running as an observer only",
+          "type": "boolean",
+          "default": false
+        },
         "active": {
           "description": "Nanoseconds since this peer was last seen",
           "type": "number"

--- a/schemas/jetstream/api/v1/consumer_create_response.json
+++ b/schemas/jetstream/api/v1/consumer_create_response.json
@@ -443,6 +443,11 @@
                     "type": "boolean",
                     "default": false
                   },
+                  "observer": {
+                    "description": "Indicates if the server is running as an observer only",
+                    "type": "boolean",
+                    "default": false
+                  },
                   "active": {
                     "description": "Nanoseconds since this peer was last seen",
                     "type": "number"

--- a/schemas/jetstream/api/v1/consumer_info_response.json
+++ b/schemas/jetstream/api/v1/consumer_info_response.json
@@ -443,6 +443,11 @@
                     "type": "boolean",
                     "default": false
                   },
+                  "observer": {
+                    "description": "Indicates if the server is running as an observer only",
+                    "type": "boolean",
+                    "default": false
+                  },
                   "active": {
                     "description": "Nanoseconds since this peer was last seen",
                     "type": "number"

--- a/schemas/jetstream/api/v1/consumer_list_response.json
+++ b/schemas/jetstream/api/v1/consumer_list_response.json
@@ -508,6 +508,11 @@
                           "type": "boolean",
                           "default": false
                         },
+                        "observer": {
+                          "description": "Indicates if the server is running as an observer only",
+                          "type": "boolean",
+                          "default": false
+                        },
                         "active": {
                           "description": "Nanoseconds since this peer was last seen",
                           "type": "number"

--- a/schemas/jetstream/api/v1/stream_create_response.json
+++ b/schemas/jetstream/api/v1/stream_create_response.json
@@ -617,6 +617,11 @@
                     "type": "boolean",
                     "default": false
                   },
+                  "observer": {
+                    "description": "Indicates if the server is running as an observer only",
+                    "type": "boolean",
+                    "default": false
+                  },
                   "active": {
                     "description": "Nanoseconds since this peer was last seen",
                     "type": "number"

--- a/schemas/jetstream/api/v1/stream_info_response.json
+++ b/schemas/jetstream/api/v1/stream_info_response.json
@@ -617,6 +617,11 @@
                     "type": "boolean",
                     "default": false
                   },
+                  "observer": {
+                    "description": "Indicates if the server is running as an observer only",
+                    "type": "boolean",
+                    "default": false
+                  },
                   "active": {
                     "description": "Nanoseconds since this peer was last seen",
                     "type": "number"

--- a/schemas/jetstream/api/v1/stream_list_response.json
+++ b/schemas/jetstream/api/v1/stream_list_response.json
@@ -682,6 +682,11 @@
                           "type": "boolean",
                           "default": false
                         },
+                        "observer": {
+                          "description": "Indicates if the server is running as an observer only",
+                          "type": "boolean",
+                          "default": false
+                        },
                         "active": {
                           "description": "Nanoseconds since this peer was last seen",
                           "type": "number"

--- a/schemas/jetstream/api/v1/stream_update_response.json
+++ b/schemas/jetstream/api/v1/stream_update_response.json
@@ -617,6 +617,11 @@
                     "type": "boolean",
                     "default": false
                   },
+                  "observer": {
+                    "description": "Indicates if the server is running as an observer only",
+                    "type": "boolean",
+                    "default": false
+                  },
                   "active": {
                     "description": "Nanoseconds since this peer was last seen",
                     "type": "number"


### PR DESCRIPTION
This is to support nats-io/nats-server#4582.

Signed-off-by: Neil Twigg <neil@nats.io>