### PR TITLE
Single filter consumer catch

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -76,6 +76,12 @@ func (m *Manager) NewConsumerFromDefault(stream string, dflt api.ConsumerConfig,
 		return nil, fmt.Errorf("configuration validation failed: %s", strings.Join(errs, ", "))
 	}
 
+	// if we have a single filter subject in the array use the single filter string instead (which will then use the extended create request subject format)
+	if len(cfg.FilterSubjects) == 1 {
+		cfg.FilterSubject = cfg.FilterSubjects[0]
+		cfg.FilterSubjects = nil
+	}
+
 	req := api.JSApiConsumerCreateRequest{
 		Stream: stream,
 		Config: *cfg,


### PR DESCRIPTION
If only one subject filter in passed in the filters array of a consumer config, use that single filter in `FilterSubject` instead such that the extended creation request subject is then used.