### PR TITLE
feat: use path from serverURL as proxyPath

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -357,7 +357,7 @@ func (c *Context) NATSOptions(opts ...nats.Option) ([]nats.Option, error) {
 		return nil, err
 	}
 
-	if u.Path != "" {
+	if u.IsAbs() && u.Path != "" {
 		nopts = append(nopts, nats.ProxyPath(u.Path))
 	}
 

--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -30,6 +30,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -349,6 +350,15 @@ func (c *Context) NATSOptions(opts ...nats.Option) ([]nats.Option, error) {
 
 	if c.InboxPrefix() != "" {
 		nopts = append(nopts, nats.CustomInboxPrefix(c.InboxPrefix()))
+	}
+
+	u, err := url.Parse(c.ServerURL())
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Path != "" {
+		nopts = append(nopts, nats.ProxyPath(u.Path))
 	}
 
 	nopts = append(nopts, opts...)


### PR DESCRIPTION
### Summary
NATS CLI cannot request WebSocket servers behind a proxy - the `proxyPath` option is missing in the config. Since another parameter would be overkill I introduce a change in the `NATSOptions` function that simply takes the path from the `serverURL` and saves it as `proxyPath` in the options object.

A related issue in CLI repo: https://github.com/nats-io/natscli/issues/639.