### PR TITLE
Revert https://github.com/nats-io/jsm.go/pull/487

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -355,15 +354,6 @@ func (c *Context) NATSOptions(opts ...nats.Option) ([]nats.Option, error) {
 
 	if c.TLSHandshakeFirst() {
 		nopts = append(nopts, nats.TLSHandshakeFirst())
-	}
-
-	u, err := url.Parse(c.ServerURL())
-	if err != nil {
-		return nil, err
-	}
-
-	if u.IsAbs() && u.Path != "" {
-		nopts = append(nopts, nats.ProxyPath(u.Path))
 	}
 
 	nopts = append(nopts, opts...)


### PR DESCRIPTION
The mentioned PR treats the nats url as a single string and then parse it as if it is one url.  The reality is multiple urls are supported there so this is simply not going to work

Further conceptually it tries to take the proxy path from the url - but as this supports multiple urls this just doesnt make sense

The right fix is for nats.go to get the proxypath behaviour per connection url rather than try to fix this here