### PR TITLE
Force consumer replicas to be 1 so the NATS CLI client is faster and …

### DIFF
--- a/stream_pager.go
+++ b/stream_pager.go
@@ -223,6 +223,7 @@ func (p *StreamPager) createConsumer() error {
 		InactiveThreshold(time.Hour),
 		DurableName(fmt.Sprintf("stream_pager_%d%d", os.Getpid(), time.Now().UnixNano())),
 		ConsumerOverrideMemoryStorage(),
+		ConsumerOverrideReplicas(1),
 	}
 
 	switch {


### PR DESCRIPTION
Force consumer replicas to be 1 so the NATS CLI client is faster and more efficient for the server. In the case of broken clusters, we also do not want to add accidental & incidental failures and timeouts when viewing streams.