### PR TITLE
Fix consumer subject filters

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -421,11 +421,14 @@ func MaxDeliveryAttempts(n int) ConsumerOption {
 func FilterStreamBySubject(s ...string) ConsumerOption {
 	return func(o *api.ConsumerConfig) error {
 		if len(s) == 1 {
+			// If there is only one filter, reset the multiple subjects filter.
+			o.FilterSubjects = nil
 			o.FilterSubject = s[0]
 		} else {
-			o.FilterSubjects = append(o.FilterSubjects, s...)
+			// If there are more subjects, reset the single subject filter.
+			o.FilterSubject = ""
+			o.FilterSubjects = s
 		}
-
 		return nil
 	}
 }


### PR DESCRIPTION
The `FilterStreamBySubject` was appending subjects instead of setting the passed value.
Additionally, it was not resetting the other filter subject field. That could cause errors, as server denies consumer API calls with both FilterSubject` and `FilterSubjects` set.`

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>