### PR TITLE
Resolves #538: add support for writing and restoring snapshots to a buffer in memory instead of requiring a file on disk

### DIFF
--- a/snapshots.go
+++ b/snapshots.go
@@ -362,7 +362,7 @@ func (s *Stream) createSnapshot(ctx context.Context, dataBuffer, metadataBuffer 
 
 	var progress *snapshotProgress
 	if sopts.progress {
-		progress := &snapshotProgress{
+		progress = &snapshotProgress{
 			startTime:     time.Now(),
 			chunkSize:     req.ChunkSize,
 			bytesExpected: resp.State.Bytes,

--- a/snapshots.go
+++ b/snapshots.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"io"
 	"log"
 	"math"
@@ -27,6 +26,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/dustin/go-humanize"
 
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats.go"
@@ -620,4 +621,264 @@ func (s *Stream) SnapshotToDirectory(ctx context.Context, dir string, opts ...Sn
 
 		return progress, nil
 	}
+}
+
+// SnapshotToBuffer creates a compressed s2 backup and writes to an io.Writer
+func (s *Stream) SnapshotToBuffer(ctx context.Context, dataBuffer, metadataBuffer io.Writer, opts ...SnapshotOption) (SnapshotProgress, error) {
+	if s.Storage() == api.MemoryStorage {
+		return nil, ErrMemoryStreamNotSupported
+	}
+
+	sopts := &snapshotOptions{
+		jsck:      false,
+		consumers: false,
+		chunkSz:   128 * 1024,
+	}
+
+	for _, opt := range opts {
+		opt(sopts)
+	}
+
+	if sopts.debug {
+		log.Printf("Starting backup of %q", s.Name())
+	}
+
+	ib := s.mgr.nc.NewRespInbox()
+	req := api.JSApiStreamSnapshotRequest{
+		DeliverSubject: ib,
+		NoConsumers:    !sopts.consumers,
+		CheckMsgs:      sopts.jsck,
+		ChunkSize:      sopts.chunkSz,
+	}
+
+	var resp api.JSApiStreamSnapshotResponse
+	err := s.mgr.jsonRequest(fmt.Sprintf(api.JSApiStreamSnapshotT, s.Name()), req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	errc := make(chan error)
+	sctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	progress := &snapshotProgress{
+		startTime:     time.Now(),
+		chunkSize:     req.ChunkSize,
+		bytesExpected: resp.State.Bytes,
+		scb:           sopts.scb,
+		rcb:           sopts.rcb,
+		healthCheck:   sopts.jsck,
+	}
+	defer func() { progress.endTime = time.Now() }()
+	go progress.trackBps(sctx)
+
+	// set up a multi writer that writes to file and the progress monitor
+	// if required else we write directly to the file and be done with it
+	trackingR, trackingW := net.Pipe()
+	defer trackingR.Close()
+	defer trackingW.Close()
+	go progress.trackBlockProgress(trackingR, sopts.debug, errc)
+
+	writer := io.MultiWriter(dataBuffer, trackingW)
+
+	// tell the caller we are starting and what to expect
+	progress.notify()
+
+	sub, err := s.mgr.nc.Subscribe(ib, func(m *nats.Msg) {
+		if len(m.Data) == 0 {
+			m.Sub.Unsubscribe()
+			cancel()
+			return
+		}
+
+		progress.Lock()
+		progress.bytesReceived += uint64(len(m.Data))
+		progress.chunksReceived++
+		progress.Unlock()
+
+		n, err := writer.Write(m.Data)
+		if err != nil {
+			errc <- err
+			return
+		}
+		if n != len(m.Data) {
+			errc <- fmt.Errorf("failed to write %d bytes to %s, only wrote %d", len(m.Data), sopts.dataFile, n)
+			return
+		}
+
+		if m.Reply != "" {
+			if sopts.debug {
+				progress.Lock()
+				log.Printf("Responding to server subject %s %s chunks, last chunk size %s", m.Reply, humanize.Comma(int64(progress.chunksReceived)), humanize.IBytes(uint64(len(m.Data))))
+				progress.Unlock()
+			}
+
+			m.Respond(nil)
+		}
+	})
+	if err != nil {
+		return progress, err
+	}
+	defer sub.Unsubscribe()
+	sub.SetPendingLimits(-1, -1)
+
+	select {
+	case err := <-errc:
+		if sopts.debug {
+			log.Printf("Snapshot Error: %s", err)
+		}
+
+		return progress, err
+	case <-sctx.Done():
+		meta := map[string]any{
+			"config": resp.Config,
+			"state":  resp.State,
+		}
+		mj, err := json.MarshalIndent(meta, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+
+		metadataBuffer.Write(mj)
+
+		progress.finished = true
+		progress.notify()
+
+		return progress, nil
+	}
+}
+
+// RestoreSnapshotFromBuffer restores a stream from a s2 compressed backup read from an io.Reader.
+func (m *Manager) RestoreSnapshotFromBuffer(ctx context.Context, stream string, dataReader, metadataReader io.Reader, opts ...SnapshotOption) (RestoreProgress, *api.StreamState, error) {
+	sopts := &snapshotOptions{
+		chunkSz: 64 * 1024,
+	}
+
+	for _, opt := range opts {
+		opt(sopts)
+	}
+
+	req := api.JSApiStreamRestoreRequest{}
+	mj, err := io.ReadAll(metadataReader)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = json.Unmarshal(mj, &req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// allow full config override
+	if sopts.restoreConfig != nil {
+		req.Config = *sopts.restoreConfig
+	}
+
+	// allow just stream name override
+	//
+	// this used to be allowed but turns out the server support for this was
+	// not up to scratch and fixing it would mean having to rebuild and re-checksum
+	// every message, so for now we error here instead
+	if req.Config.Name != stream {
+		return nil, nil, fmt.Errorf("stream name may not be changed during restore")
+	}
+
+	if req.Config.Storage == api.MemoryStorage {
+		return nil, nil, ErrMemoryStreamNotSupported
+	}
+
+	var resp api.JSApiStreamRestoreResponse
+	err = m.jsonRequest(fmt.Sprintf(api.JSApiStreamRestoreT, req.Config.Name), req, &resp)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	progress := &snapshotProgress{
+		startTime: time.Now(),
+		chunkSize: sopts.chunkSz,
+		// chunksToSend: 1 + int(fstat.Size())/sopts.chunkSz,
+		sending: true,
+		rcb:     sopts.rcb,
+		scb:     sopts.scb,
+	}
+	defer func() { progress.endTime = time.Now() }()
+	go progress.trackBps(ctx)
+
+	if sopts.debug {
+		log.Printf("Starting restore of %q from %s using %d chunks", req.Config.Name, sopts.dataFile, progress.chunksToSend)
+	}
+
+	// in debug notify ~20ish times
+	// notifyInterval := uint32(1)
+	// if progress.chunksToSend >= 20 {
+	// 	notifyInterval = uint32(math.Ceil(float64(progress.chunksToSend) / 20))
+	// }
+
+	// send initial notify to inform what to expect
+	progress.notify()
+
+	nc := m.nc
+	var chunk [64 * 1024]byte
+	var cresp *nats.Msg
+
+	for {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+
+		n, err := dataReader.Read(chunk[:])
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
+		cresp, err = nc.Request(resp.DeliverSubject, chunk[:n], m.timeout)
+		if err != nil {
+			return nil, nil, err
+		}
+		if IsErrorResponse(cresp) {
+			return nil, nil, fmt.Errorf("restore failed: %q", cresp.Data)
+		}
+
+		// if sopts.debug && progress.chunksSent > 0 && progress.chunksSent%notifyInterval == 0 {
+		// 	log.Printf("Sent %d chunks", progress.chunksSent)
+		// }
+
+		progress.Lock()
+		progress.chunksSent++
+		progress.bytesSent += uint64(n)
+		progress.Unlock()
+
+		progress.notify()
+	}
+
+	if sopts.debug {
+		log.Printf("Sent %d chunks, server will now restore the snapshot, this might take a long time", progress.chunksSent)
+	}
+
+	// very long timeout as the server is doing the restore here and might take any mount of time
+	cresp, err = nc.Request(resp.DeliverSubject, nil, time.Hour)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kind, finalr, err := api.ParseMessage(cresp.Data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if kind != "io.nats.jetstream.api.v1.stream_create_response" {
+		return nil, nil, fmt.Errorf("invalid final response, expected a io.nats.jetstream.api.v1.stream_create_response message but got %q", kind)
+	}
+
+	createResp, ok := finalr.(*api.JSApiStreamCreateResponse)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid final response type")
+	}
+	if createResp.IsError() {
+		return nil, nil, createResp.ToError()
+	}
+
+	return progress, &createResp.State, nil
 }


### PR DESCRIPTION
Support creating and restoring snapshots from `io.Reader` and `io.Writer` instead of a file on disk.