### PR TITLE
[ADD] DeliverBodies to disable headersOnly

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -360,10 +360,20 @@ func StartAtTimeDelta(d time.Duration) ConsumerOption {
 	}
 }
 
-// DeliverHeadersOnly configures the consumer to only deliver existing header and the `Nats-Msg-Size` header, no bodies
+// DeliverHeadersOnly configures the consumer to only deliver existing header and the `Nats-Msg-Size` header, no bodies.
+// To deliver also the bodies use DeliverBodies.
 func DeliverHeadersOnly() ConsumerOption {
 	return func(o *api.ConsumerConfig) error {
 		o.HeadersOnly = true
+		return nil
+	}
+}
+
+// DeliverBodies configures the consumer to deliver the headers and the bodies for each message.
+// To only deliver headers only use DeliverHeadersOnly.
+func DeliverBodies() ConsumerOption {
+	return func(o *api.ConsumerConfig) error {
+		o.HeadersOnly = false
 		return nil
 	}
 }

--- a/test/consumers_test.go
+++ b/test/consumers_test.go
@@ -915,11 +915,15 @@ func TestMaxWaiting(t *testing.T) {
 	}
 }
 
-func TestDeliverHeadersOnly(t *testing.T) {
+func TestDeliverHeadersOnlyAndDeliverBodies(t *testing.T) {
 	cfg := testConsumerConfig()
 	jsm.DeliverHeadersOnly()(cfg)
 	if !cfg.HeadersOnly {
 		t.Fatalf("expected headers only to be set")
+	}
+	jsm.DeliverBodies()(cfg)
+	if cfg.HeadersOnly {
+		t.Fatalf("expected headers only to be false")
 	}
 }
 


### PR DESCRIPTION
Add DeliverBodies, which allows a consumer to be updated with headersOnly: false

This change will also be helpful for Nack: https://github.com/nats-io/nack/blob/main/controllers/jetstream/consumer.go#L408-L410