### PR TITLE
(#1129) - Fix cluster and mirror checks

### DIFF
--- a/monitor/stream_test.go
+++ b/monitor/stream_test.go
@@ -425,7 +425,11 @@ func TestStream_checkCluster(t *testing.T) {
 				Replicas: []*api.PeerInfo{
 					{Name: "p1"},
 				},
-			}}
+			},
+			Config: api.StreamConfig{
+				Replicas: 2,
+			},
+		}
 
 		streamCheckCluster(si, check, StreamHealthCheckOptions{
 			ClusterExpectedPeers: 3,
@@ -442,6 +446,9 @@ func TestStream_checkCluster(t *testing.T) {
 					{Name: "p2"},
 					{Name: "p3"},
 				},
+			},
+			Config: api.StreamConfig{
+				Replicas: 3,
 			},
 		}
 
@@ -476,6 +483,9 @@ func TestStream_checkCluster(t *testing.T) {
 					{Name: "p3", Lag: 10},
 				},
 			},
+			Config: api.StreamConfig{
+				Replicas: 3,
+			},
 		}
 
 		streamCheckCluster(si, check, StreamHealthCheckOptions{
@@ -494,6 +504,9 @@ func TestStream_checkCluster(t *testing.T) {
 					{Name: "p2", Lag: 10, Active: time.Second},
 					{Name: "p3", Lag: 10, Active: time.Hour},
 				},
+			},
+			Config: api.StreamConfig{
+				Replicas: 3,
 			},
 		}
 
@@ -515,6 +528,9 @@ func TestStream_checkCluster(t *testing.T) {
 					{Name: "p3", Lag: 10, Active: time.Hour},
 				},
 			},
+			Config: api.StreamConfig{
+				Replicas: 3,
+			},
 		}
 
 		streamCheckCluster(si, check, StreamHealthCheckOptions{
@@ -533,6 +549,9 @@ func TestStream_checkCluster(t *testing.T) {
 					{Name: "p2", Lag: 10, Active: time.Second},
 					{Name: "p3", Lag: 10, Active: time.Second},
 				},
+			},
+			Config: api.StreamConfig{
+				Replicas: 3,
 			},
 		}
 		streamCheckCluster(si, check, StreamHealthCheckOptions{


### PR DESCRIPTION
Here we fix the cluster check to make sure that we don't run it if no ClusterExpectedPeers have been defined.

We also clean up the Mirror check to not run when sources have been defined, since the two are mutually exclusive.