### PR TITLE
Fix stream snapshot error messaging

### DIFF
--- a/snapshots.go
+++ b/snapshots.go
@@ -52,7 +52,8 @@ type snapshotOptions struct {
 }
 
 const (
-	ClientInfoHdr string = "Nats-Request-Info"
+	StatusHdr      string = "Status"
+	DescriptionHdr string = "Description"
 )
 
 // ErrMemoryStreamNotSupported is an error indicating a memory stream was being snapshotted which is not supported
@@ -396,17 +397,16 @@ func (s *Stream) createSnapshot(ctx context.Context, dataBuffer, metadataBuffer 
 
 	sub, err := s.mgr.nc.Subscribe(ib, func(m *nats.Msg) {
 		if len(m.Data) == 0 {
-			m.Sub.Unsubscribe()
-			cancel()
-
-			clientInfoHeader := m.Header.Get(ClientInfoHdr)
+			statusValue := m.Header.Get(StatusHdr)
 
 			// if the server returns a non-204 status code in the message header, return an error
-			if clientInfoHeader != "" && !strings.Contains(clientInfoHeader, "204") {
-				errc <- errors.New(clientInfoHeader)
-				return
+			if statusValue != "" && !strings.Contains(statusValue, "204") {
+				descriptionValue := m.Header.Get(DescriptionHdr)
+				errc <- fmt.Errorf("%s %s", statusValue, descriptionValue)
 			}
 
+			m.Sub.Unsubscribe()
+			cancel()
 			return
 		}
 


### PR DESCRIPTION
https://github.com/nats-io/jsm.go/pull/545 introduced checking if during a stream snapshot there was some sort of error.

However `Nats-Request-Info` was checked which doesn't seem to contain this info.
The server reports the header `NATS/1.0 408 No Interest` which is reflected in the headers as:
`{Status: "408", Description: "No Interest"}`.

Source for reference: https://github.com/nats-io/nats-server/blob/a07bde9fa7d499c7039f74cac9d11f4c046b9250/server/jetstream_api.go#L3826

This PR fixes using the correct header, and also only calling `cancel()` after we've added the error to the `errc` as otherwise the error would not be logged.