### PR TITLE
(#577) Tilde expand context paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	go.uber.org/automaxprocs v1.6.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/time v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nats-io/jwt/v2 v2.7.0 h1:J+ZnaaMGQi3xSB8iOhVM5ipiWCDrQvgEoitTwWFyOYw=
 github.com/nats-io/jwt/v2 v2.7.0/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
-github.com/nats-io/nats-server/v2 v2.11.0-dev.0.20240919192050-816061f4f441 h1:zRz6lR7kpJGsScHQldbr0LFSzC5BWiX1r08oDgp42Tw=
-github.com/nats-io/nats-server/v2 v2.11.0-dev.0.20240919192050-816061f4f441/go.mod h1:7ME9V++zVk2hoBe5VOvq/WMQuOuNeyhG63bOwWWokZY=
 github.com/nats-io/nats-server/v2 v2.11.0-dev.0.20241004162106-225cd3dd6eca h1:EcjPbDziop5sCVOpWOhUXTcQPAg1of3p+MgczwJubUo=
 github.com/nats-io/nats-server/v2 v2.11.0-dev.0.20241004162106-225cd3dd6eca/go.mod h1:LkVD8QXFfIxYsQCn3r0NHJk48PIg2XY1RqVBDTQwYuU=
 github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
@@ -56,8 +54,6 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
-go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
 golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=

--- a/natscontext/context_test.go
+++ b/natscontext/context_test.go
@@ -127,21 +127,4 @@ func TestContext(t *testing.T) {
 	if err != nil || (config.Name != "gotest" && config.ServerURL() != "demo.nats.io" && config.Token() != "use-nkeys!") {
 		t.Fatalf("could not load context file: %s", err)
 	}
-
-	// test tilde expansion
-	if config.NKey() == "~/.keys/nats/example/prod.nkey" {
-		t.Fatalf("invalid expansion of HOME directory - %s", config.NKey())
-	}
-	if config.Creds() == "~/.keys/nats/example/creds" {
-		t.Fatalf("invalid expansion of HOME directory - %s", config.Creds())
-	}
-	if config.Certificate() == "~/.keys/nats/example/public.crt" {
-		t.Fatalf("invalid expansion of HOME directory - %s", config.Certificate())
-	}
-	if config.Key() == "~/.keys/nats/example/public.key" {
-		t.Fatalf("invalid expansion of HOME directory - %s", config.Key())
-	}
-	if config.CA() == "~/.keys/nats/example/public.ca" {
-		t.Fatalf("invalid expansion of HOME directory - %s", config.CA())
-	}
 }

--- a/natscontext/expansion_test.go
+++ b/natscontext/expansion_test.go
@@ -1,0 +1,23 @@
+package natscontext
+
+import "testing"
+
+func TestContext(t *testing.T) {
+	// Do nothing if the string does not start with ~
+	t1 := expandHomedir("foo")
+	if t1 != "foo" {
+		t.Fatalf("failed to expand home directory for string 'foo': %s", t1)
+	}
+
+	// Expand ~ to HOMEDIR if string starts with ~
+	t2 := expandHomedir("~/foo")
+	if t2 == "~/foo" {
+		t.Fatalf("failed to expand home directory for string 'foo': %s", t2)
+	}
+
+	// Do nothing if there is a ~ but it is not the first character of the string
+	t3 := expandHomedir("/~/foo")
+	if t3 != "/~/foo" {
+		t.Fatalf("failed to expand home directory for string 'foo': %s", t3)
+	}
+}


### PR DESCRIPTION
Here we move tilde expansion to be as late as possible.

This prevents cli actions like `nats context edit` from rewriting the value of the path to file, and instead only expanding the tilde when needed.