### PR TITLE
Revert 94286c087cbef2c36c8abdd3eb6e0d537d02f777

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -76,13 +76,6 @@ func (m *Manager) NewConsumerFromDefault(stream string, dflt api.ConsumerConfig,
 		return nil, fmt.Errorf("configuration validation failed: %s", strings.Join(errs, ", "))
 	}
 
-	// TODO: Remove this once natscli and the Terraform NATS provider are using update consumer
-	// if we have a single filter subject in the array use the single filter string instead (which will then use the extended create request subject format)
-	if len(cfg.FilterSubjects) == 1 {
-		cfg.FilterSubject = cfg.FilterSubjects[0]
-		cfg.FilterSubjects = nil
-	}
-
 	req := api.JSApiConsumerCreateRequest{
 		Stream:   stream,
 		Config:   *cfg,


### PR DESCRIPTION
This reverts 94286c087cbef2c36c8abdd3eb6e0d537d02f777 which introduced an under the covers change of user intent from single entry multi filters into a single filter, this was done to force the filter subject based consumer create to be used.

Problem is no other client does this so whatever backward compatible hopes there is or security gains just isn't realised and its just an unintended foot gun now