### PR TITLE
Create a collection of checks rather than global

### DIFF
--- a/audit/account_checks.go
+++ b/audit/account_checks.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The NATS Authors
+// Copyright 2024-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,8 +21,8 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-func init() {
-	MustRegisterCheck(Check{
+func RegisterAccountChecks(collection *CheckCollection) error {
+	return collection.Register(Check{
 		Code:        "ACCOUNTS_001",
 		Name:        "Account Limits",
 		Description: "Account usage is below the configured limits",

--- a/audit/cluster_checks.go
+++ b/audit/cluster_checks.go
@@ -25,8 +25,8 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-func init() {
-	MustRegisterCheck(
+func RegisterClusterChecks(collection *CheckCollection) error {
+	return collection.Register(
 		Check{
 			Code:        "CLUSTER_001",
 			Name:        "Cluster Memory Usage Outliers",

--- a/audit/configuration.go
+++ b/audit/configuration.go
@@ -1,0 +1,96 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+)
+
+// CheckConfiguration describes and holds the configuration for a check
+type CheckConfiguration struct {
+	Key         string            `json:"key"`
+	Check       string            `json:"check"`
+	Description string            `json:"description"`
+	Default     float64           `json:"default"`
+	Unit        ConfigurationUnit `json:"unit"`
+	SetValue    *float64          `json:"set_value,omitempty"`
+}
+
+type ConfigurationUnit string
+
+const (
+	PercentageUnit ConfigurationUnit = "%"
+	IntUnit        ConfigurationUnit = "int"
+	UIntUnit       ConfigurationUnit = "uint"
+)
+
+// Value retrieves the set value or default value
+func (c *CheckConfiguration) Value() float64 {
+	if c.SetValue != nil {
+		return *c.SetValue
+	}
+
+	return c.Default
+}
+
+func (c *CheckConfiguration) String() string {
+	return humanize.Commaf(c.Value())
+}
+
+// Set supports fisk
+func (c *CheckConfiguration) Set(v string) error {
+	var f float64
+	var err error
+
+	if c.Unit == PercentageUnit {
+		f, err = strconv.ParseFloat(strings.TrimRight(v, "%"), 64)
+		if err != nil {
+			return err
+		}
+		if f < 0 {
+			return fmt.Errorf("percentage values must be positive")
+		}
+		if f > 100 {
+			return fmt.Errorf("percentage values may not exceed 100")
+		}
+
+		if f > 1 {
+			f = f / 100
+		}
+	} else {
+		f, err = strconv.ParseFloat(v, 64)
+		if err != nil {
+			return err
+		}
+
+		if c.Unit == UIntUnit {
+			if f < 0 {
+				return fmt.Errorf("value must be positive")
+			}
+		}
+	}
+
+	c.SetValue = &f
+
+	return nil
+}
+
+// SetVal supports fisk
+//func (c *CheckConfiguration) SetVal(s fisk.Settings) {
+//	s.SetValue(c)
+//}

--- a/audit/leafnode_checks.go
+++ b/audit/leafnode_checks.go
@@ -21,8 +21,8 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func init() {
-	MustRegisterCheck(
+func RegisterLeafnodeChecks(collection *CheckCollection) error {
+	return collection.Register(
 		Check{
 			Code:        "LEAF_001",
 			Name:        "Whitespace in leafnode server names",

--- a/audit/metacluster_checks.go
+++ b/audit/metacluster_checks.go
@@ -21,8 +21,8 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-func init() {
-	MustRegisterCheck(
+func RegisterMetaChecks(collection *CheckCollection) error {
+	return collection.Register(
 		Check{
 			Code:        "META_001",
 			Name:        "Meta cluster offline replicas",

--- a/audit/server_checks.go
+++ b/audit/server_checks.go
@@ -23,8 +23,8 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-func init() {
-	MustRegisterCheck(
+func RegisterServerChecks(collection *CheckCollection) error {
+	return collection.Register(
 		Check{
 			Code:        "SERVER_001",
 			Name:        "Server Health",

--- a/audit/stream_checks.go
+++ b/audit/stream_checks.go
@@ -21,8 +21,8 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 )
 
-func init() {
-	MustRegisterCheck(
+func RegisterJetStreamChecks(collection *CheckCollection) error {
+	return collection.Register(
 		Check{
 			Code:        "STREAM_001",
 			Name:        "Stream Lagging Replicas",


### PR DESCRIPTION
This to improve using audit checks in multi threaded applications where each instance of the collection can have different sets of checks loaded