### PR TITLE
Store raw server responses when gathering

### DIFF
--- a/audit/archive/writer.go
+++ b/audit/archive/writer.go
@@ -102,7 +102,7 @@ func (w *Writer) SetTime(t time.Time) {
 
 // AddRaw adds the given artifact to the archive similarly to Add.
 // The artifact is assumed to be already serialized and is copied as-is byte for byte.
-func (w *Writer) AddRaw(reader *bytes.Reader, extension string, tags ...*Tag) error {
+func (w *Writer) AddRaw(reader io.Reader, extension string, tags ...*Tag) error {
 	if w.zipWriter == nil {
 		return fmt.Errorf("attempting to write into a closed writer")
 	}


### PR DESCRIPTION
Previously the responses would be ran through data types and then saved again for no good reason, this had the side effect of losing data for a gather process using older structs than the server generating the data

Now we store the data as received only indenting it for readability