### PR TITLE
Update definitions.json redelivered-> delivered

### DIFF
--- a/schema_source/jetstream/api/v1/definitions.json
+++ b/schema_source/jetstream/api/v1/definitions.json
@@ -725,7 +725,7 @@
         },
         "max_deliver": {
           "$ref": "#/definitions/golang_int",
-          "description": "The number of times a message will be redelivered to consumers if not acknowledged in time",
+          "description": "The number of times a message will be delivered to consumers if not acknowledged in time",
           "default": -1
         },
         "filter_subject": {


### PR DESCRIPTION
Similar to https://github.com/nats-io/nats.js/issues/186

It was added in https://github.com/nats-io/nats-server/commit/89ff13a5be680fda3fae2f2b53a12776928b82ed#diff-172561e6cce90cfe99be04c3a0381c1c019b97b809a429d87e60934e96f06139R823

And I did confirm that the number is compared to delivery count:
https://github.com/nats-io/nats-server/blob/5137ad891865be498a8f2ef42426033bd09c82d7/server/consumer.go#L4009