### PR TITLE
Expect jsm options on JS related monitors

### DIFF
--- a/monitor/consumer.go
+++ b/monitor/consumer.go
@@ -134,7 +134,7 @@ func ConsumerInfoHealthCheck(nfo *api.ConsumerInfo, check *Result, opts Consumer
 	consumerCheckPinned(nfo, check, opts, log)
 }
 
-func ConsumerHealthCheck(server string, nopts []nats.Option, check *Result, opts ConsumerHealthCheckOptions, log api.Logger) error {
+func ConsumerHealthCheck(server string, nopts []nats.Option, jsmOpts []jsm.Option, check *Result, opts ConsumerHealthCheckOptions, log api.Logger) error {
 	if opts.StreamName == "" {
 		check.Critical("stream name is required")
 		return nil
@@ -149,7 +149,7 @@ func ConsumerHealthCheck(server string, nopts []nats.Option, check *Result, opts
 		return nil
 	}
 
-	mgr, err := jsm.New(nc)
+	mgr, err := jsm.New(nc, jsmOpts...)
 	if check.CriticalIfErr(err, "could not load info: %v", err) {
 		return nil
 	}

--- a/monitor/js_account.go
+++ b/monitor/js_account.go
@@ -37,7 +37,7 @@ type CheckJetStreamAccountOptions struct {
 	Resolver func() *api.JetStreamAccountStats `json:"-" yaml:"-"`
 }
 
-func CheckJetStreamAccount(server string, nopts []nats.Option, check *Result, opts CheckJetStreamAccountOptions) error {
+func CheckJetStreamAccount(server string, nopts []nats.Option, jsmOpts []jsm.Option, check *Result, opts CheckJetStreamAccountOptions) error {
 	var mgr *jsm.Manager
 	var err error
 
@@ -47,7 +47,7 @@ func CheckJetStreamAccount(server string, nopts []nats.Option, check *Result, op
 			return nil
 		}
 
-		mgr, err = jsm.New(nc)
+		mgr, err = jsm.New(nc, jsmOpts...)
 		if check.CriticalIfErr(err, "setup failed: %v", err) {
 			return nil
 		}

--- a/monitor/js_account_test.go
+++ b/monitor/js_account_test.go
@@ -58,7 +58,7 @@ func TestCheckAccountInfo(t *testing.T) {
 	t.Run("No limits, default thresholds", func(t *testing.T) {
 		opts, info, check := setDefaults()
 		info.Limits = api.JetStreamAccountLimits{}
-		assertNoError(t, monitor.CheckJetStreamAccount("", nil, check, *opts))
+		assertNoError(t, monitor.CheckJetStreamAccount("", nil, nil, check, *opts))
 		assertListIsEmpty(t, check.Criticals)
 		assertListIsEmpty(t, check.Warnings)
 		assertHasPDItem(t, check, "memory=128B memory_pct=0%;75;90 storage=1024B storage_pct=0%;75;90 streams=10 streams_pct=0% consumers=100 consumers_pct=0%")
@@ -66,7 +66,7 @@ func TestCheckAccountInfo(t *testing.T) {
 
 	t.Run("Limits, default thresholds", func(t *testing.T) {
 		opts, _, check := setDefaults()
-		assertNoError(t, monitor.CheckJetStreamAccount("", nil, check, *opts))
+		assertNoError(t, monitor.CheckJetStreamAccount("", nil, nil, check, *opts))
 		assertListIsEmpty(t, check.Criticals)
 		assertListIsEmpty(t, check.Warnings)
 		assertHasPDItem(t, check, "memory=128B memory_pct=12%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%")
@@ -76,7 +76,7 @@ func TestCheckAccountInfo(t *testing.T) {
 		t.Run("Usage exceeds max", func(t *testing.T) {
 			opts, info, check := setDefaults()
 			info.Streams = 300
-			assertNoError(t, monitor.CheckJetStreamAccount("", nil, check, *opts))
+			assertNoError(t, monitor.CheckJetStreamAccount("", nil, nil, check, *opts))
 			assertListEquals(t, check.Criticals, "streams: exceed server limits")
 			assertListIsEmpty(t, check.Warnings)
 			assertHasPDItem(t, check, "memory=128B memory_pct=12%;75;90 storage=1024B storage_pct=5%;75;90 streams=300 streams_pct=150% consumers=100 consumers_pct=10%")
@@ -86,14 +86,14 @@ func TestCheckAccountInfo(t *testing.T) {
 			opts, _, check := setDefaults()
 			opts.MemoryWarning = 90
 			opts.MemoryCritical = 80
-			assertNoError(t, monitor.CheckJetStreamAccount("", nil, check, *opts))
+			assertNoError(t, monitor.CheckJetStreamAccount("", nil, nil, check, *opts))
 			assertListEquals(t, check.Criticals, "memory: invalid thresholds")
 		})
 
 		t.Run("Exceeds warning threshold", func(t *testing.T) {
 			opts, info, check := setDefaults()
 			info.Memory = 800
-			assertNoError(t, monitor.CheckJetStreamAccount("", nil, check, *opts))
+			assertNoError(t, monitor.CheckJetStreamAccount("", nil, nil, check, *opts))
 			assertHasPDItem(t, check, "memory=800B memory_pct=78%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%")
 			assertListIsEmpty(t, check.Criticals)
 			assertListEquals(t, check.Warnings, "78% memory")
@@ -103,7 +103,7 @@ func TestCheckAccountInfo(t *testing.T) {
 			opts, info, check := setDefaults()
 
 			info.Memory = 960
-			assertNoError(t, monitor.CheckJetStreamAccount("", nil, check, *opts))
+			assertNoError(t, monitor.CheckJetStreamAccount("", nil, nil, check, *opts))
 			assertHasPDItem(t, check, "memory=960B memory_pct=93%;75;90 storage=1024B storage_pct=5%;75;90 streams=10 streams_pct=5% consumers=100 consumers_pct=10%")
 			assertListEquals(t, check.Criticals, "93% memory")
 			assertListIsEmpty(t, check.Warnings)

--- a/monitor/stream.go
+++ b/monitor/stream.go
@@ -162,7 +162,7 @@ func CheckStreamInfoHealth(nfo *api.StreamInfo, check *Result, opts CheckStreamH
 	streamCheckMirror(nfo, check, opts, log)
 }
 
-func CheckStreamHealth(server string, nopts []nats.Option, check *Result, opts CheckStreamHealthOptions, log api.Logger) error {
+func CheckStreamHealth(server string, nopts []nats.Option, jsmOpts []jsm.Option, check *Result, opts CheckStreamHealthOptions, log api.Logger) error {
 	if opts.StreamName == "" {
 		check.Critical("stream name is required")
 		return nil
@@ -173,7 +173,7 @@ func CheckStreamHealth(server string, nopts []nats.Option, check *Result, opts C
 		return nil
 	}
 
-	mgr, err := jsm.New(nc)
+	mgr, err := jsm.New(nc, jsmOpts...)
 	if check.CriticalIfErr(err, "could not load info: %v", err) {
 		return nil
 	}

--- a/monitor/stream_msg.go
+++ b/monitor/stream_msg.go
@@ -40,13 +40,13 @@ type CheckStreamMessageOptions struct {
 	BodyAsTimestamp bool `json:"body_as_timestamp" yaml:"body_as_timestamp"`
 }
 
-func CheckStreamMessage(server string, nopts []nats.Option, check *Result, opts CheckStreamMessageOptions) error {
+func CheckStreamMessage(server string, nopts []nats.Option, jsmOpts []jsm.Option, check *Result, opts CheckStreamMessageOptions) error {
 	nc, err := nats.Connect(server, nopts...)
 	if check.CriticalIfErr(err, "could not load info: %v", err) {
 		return nil
 	}
 
-	mgr, err := jsm.New(nc)
+	mgr, err := jsm.New(nc, jsmOpts...)
 	if check.CriticalIfErr(err, "could not load info: %v", err) {
 		return nil
 	}

--- a/monitor/stream_msg_test.go
+++ b/monitor/stream_msg_test.go
@@ -42,7 +42,7 @@ func TestCheckMessage(t *testing.T) {
 				AgeWarning:      1,
 				BodyAsTimestamp: true,
 			}
-			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, check, opts))
+			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, nil, check, opts))
 			assertListIsEmpty(t, check.Warnings)
 			assertListIsEmpty(t, check.OKs)
 			assertListEquals(t, check.Criticals, "no message found")
@@ -52,7 +52,7 @@ func TestCheckMessage(t *testing.T) {
 			checkErr(t, err, "publish failed: %v", err)
 
 			check = &monitor.Result{}
-			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, check, opts))
+			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, nil, check, opts))
 			assertListIsEmpty(t, check.Warnings)
 			assertListIsEmpty(t, check.Criticals)
 			assertListEquals(t, check.OKs, "Valid message on TEST > TEST")
@@ -62,7 +62,7 @@ func TestCheckMessage(t *testing.T) {
 			checkErr(t, err, "publish failed: %v", err)
 
 			check = &monitor.Result{}
-			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, check, opts))
+			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, nil, check, opts))
 			assertListIsEmpty(t, check.Criticals)
 			if len(check.Warnings) != 1 {
 				t.Fatalf("expected 1 warning got: %v", check.Warnings)
@@ -73,7 +73,7 @@ func TestCheckMessage(t *testing.T) {
 			checkErr(t, err, "publish failed: %v", err)
 
 			check = &monitor.Result{}
-			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, check, opts))
+			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, nil, check, opts))
 			assertListIsEmpty(t, check.Warnings)
 			if len(check.Criticals) != 1 {
 				t.Fatalf("expected 1 critical got: %v", check.Criticals)
@@ -81,7 +81,7 @@ func TestCheckMessage(t *testing.T) {
 
 			opts.BodyAsTimestamp = false
 			check = &monitor.Result{}
-			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, check, opts))
+			assertNoError(t, monitor.CheckStreamMessage(srv.ClientURL(), nil, nil, check, opts))
 			assertListIsEmpty(t, check.Warnings)
 			assertListIsEmpty(t, check.Criticals)
 			assertListEquals(t, check.OKs, "Valid message on TEST > TEST")


### PR DESCRIPTION
This enables domains, trace etc to be used