### PR TITLE
Add a noexprlang build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,10 @@ This can be used by the `Manager` to validate all API access.
 ```go
 mgr, _ := jsm.New(nc, jsm.WithAPIValidation(new(SchemaValidator)))
 ```
+
+## Build tag
+
+This library provides a `noexprlang` build tag that disables expression matching
+for Streams and Consumers queries. The purpose of this build tag is to disable
+the use of the `github.com/expr-lang/expr` module that disables go compiler's dead
+code elimination because it uses some types and functions of the `reflect` package.

--- a/jsm.go
+++ b/jsm.go
@@ -31,6 +31,10 @@ import (
 	"github.com/nats-io/jsm.go/api"
 )
 
+// ErrNoExprLangBuild warns that expression matching is disabled when compiling
+// a go binary with the `noexprlang` build tag.
+var ErrNoExprLangBuild = fmt.Errorf("binary has been built with `noexprlang` build tag and thus does not support expression matching")
+
 // standard api responses with error embedded
 type jetStreamResponseError interface {
 	ToError() error

--- a/match.go
+++ b/match.go
@@ -1,0 +1,127 @@
+//go:build !noexprlang
+
+package jsm
+
+import (
+	"fmt"
+
+	"github.com/expr-lang/expr"
+	"gopkg.in/yaml.v3"
+)
+
+// StreamQueryExpression filters the stream using the expr expression language
+// Using this option with a binary built with the `noexprlang` build tag will
+// always return [ErrNoExprLangBuild].
+func StreamQueryExpression(e string) StreamQueryOpt {
+	return func(q *streamQuery) error {
+		q.expression = e
+		return nil
+	}
+}
+
+func (q *streamQuery) matchExpression(streams []*Stream) ([]*Stream, error) {
+	if q.expression == "" {
+		return streams, nil
+	}
+
+	var matched []*Stream
+
+	for _, stream := range streams {
+		cfg := map[string]any{}
+		state := map[string]any{}
+		info := map[string]any{}
+
+		cfgBytes, _ := yaml.Marshal(stream.Configuration())
+		yaml.Unmarshal(cfgBytes, &cfg)
+		nfo, _ := stream.LatestInformation()
+		nfoBytes, _ := yaml.Marshal(nfo)
+		yaml.Unmarshal(nfoBytes, &info)
+		stateBytes, _ := yaml.Marshal(nfo.State)
+		yaml.Unmarshal(stateBytes, &state)
+
+		env := map[string]any{
+			"config": cfg,
+			"state":  state,
+			"info":   info,
+			"Info":   nfo,
+		}
+
+		program, err := expr.Compile(q.expression, expr.Env(env), expr.AsBool())
+		if err != nil {
+			return nil, err
+		}
+
+		out, err := expr.Run(program, env)
+		if err != nil {
+			return nil, err
+		}
+
+		should, ok := out.(bool)
+		if !ok {
+			return nil, fmt.Errorf("expression did not return a boolean")
+		}
+
+		if should {
+			matched = append(matched, stream)
+		}
+	}
+
+	return matched, nil
+}
+
+// ConsumerQueryExpression filters the consumers using the expr expression language
+// Using this option with a binary built with the `noexprlang` build tag will
+// always return [ErrNoExprLangBuild].
+func ConsumerQueryExpression(e string) ConsumerQueryOpt {
+	return func(q *consumerQuery) error {
+		q.expression = e
+		return nil
+	}
+}
+
+func (q *consumerQuery) matchExpression(consumers []*Consumer) ([]*Consumer, error) {
+	if q.expression == "" {
+		return consumers, nil
+	}
+
+	var matched []*Consumer
+
+	for _, consumer := range consumers {
+		cfg := map[string]any{}
+		state := map[string]any{}
+
+		cfgBytes, _ := yaml.Marshal(consumer.Configuration())
+		yaml.Unmarshal(cfgBytes, &cfg)
+		nfo, _ := consumer.LatestState()
+		stateBytes, _ := yaml.Marshal(nfo)
+		yaml.Unmarshal(stateBytes, &state)
+
+		env := map[string]any{
+			"config": cfg,
+			"state":  state,
+			"info":   state,
+			"Info":   nfo,
+		}
+
+		program, err := expr.Compile(q.expression, expr.Env(env), expr.AsBool())
+		if err != nil {
+			return nil, err
+		}
+
+		out, err := expr.Run(program, env)
+		if err != nil {
+			return nil, err
+		}
+
+		should, ok := out.(bool)
+		if !ok {
+			return nil, fmt.Errorf("expression did not return a boolean")
+		}
+
+		if should {
+			matched = append(matched, consumer)
+		}
+	}
+
+	return matched, nil
+}

--- a/match_noexpr.go
+++ b/match_noexpr.go
@@ -1,0 +1,37 @@
+//go:build noexprlang
+
+package jsm
+
+// StreamQueryExpression filters the stream using the expr expression language
+// Using this option with a binary built with the `noexprlang` build tag will
+// always return [ErrNoExprLangBuild].
+func StreamQueryExpression(e string) StreamQueryOpt {
+	return func(q *streamQuery) error {
+		q.expression = e
+		return ErrNoExprLangBuild
+	}
+}
+
+func (q *streamQuery) matchExpression(streams []*Stream) ([]*Stream, error) {
+	if q.expression == "" {
+		return streams, nil
+	}
+	return nil, ErrNoExprLangBuild
+}
+
+// ConsumerQueryExpression filters the consumers using the expr expression language
+// Using this option with a binary built with the `noexprlang` build tag will
+// always return [ErrNoExprLangBuild].
+func ConsumerQueryExpression(e string) ConsumerQueryOpt {
+	return func(q *consumerQuery) error {
+		q.expression = e
+		return ErrNoExprLangBuild
+	}
+}
+
+func (q *consumerQuery) matchExpression(consumers []*Consumer) ([]*Consumer, error) {
+	if q.expression == "" {
+		return consumers, nil
+	}
+	return nil, ErrNoExprLangBuild
+}


### PR DESCRIPTION
This module uses `github.com/expr-lang/expr` which, because of the extensive use of the `reflect` package, disables go's compiler dead code elimination which can lead to bigger binaries.

This commit adds a `noexprlang` build tag that allows jsm.go users that do not use expression matching to entirely disable the use of the expr module so that they can benefit from go's dead code elimination if they are eligible to outside jsm.go.

References:
- https://golab.io/talks/getting-the-most-out-of-dead-code-elimination
- https://github.com/aarzilli/whydeadcode
- https://github.com/spf13/cobra/pull/1956