### PR TITLE
Fixed invalid consumer info schema

### DIFF
--- a/schema_source/jetstream/api/v1/definitions.json
+++ b/schema_source/jetstream/api/v1/definitions.json
@@ -673,9 +673,9 @@
           "description": "Indicates if the consumer is currently in a paused state",
           "type": "boolean"
         },
-        "pause_until": {
-          "description": "A deadline time for when the consumer will be paused. Only usable if 'paused' is true",
-          "$ref": "#/definitions/golang_time"
+        "pause_remaining": {
+          "description": "When paused the time remaining until unpause",
+          "$ref": "#/definitions/golang_duration_nanos"
         },
         "priority_groups": {
           "description": "The state of Priority Groups",

--- a/schemas/jetstream/api/v1/consumer_create_response.json
+++ b/schemas/jetstream/api/v1/consumer_create_response.json
@@ -536,11 +536,12 @@
           "description": "Indicates if the consumer is currently in a paused state",
           "type": "boolean"
         },
-        "pause_until": {
-          "description": "A deadline time for when the consumer will be paused. Only usable if 'paused' is true",
-          "$comment": "A point in time in RFC3339 format including timezone, though typically in UTC",
-          "type": "string",
-          "format": "date-time"
+        "pause_remaining": {
+          "description": "When paused the time remaining until unpause",
+          "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
+          "type": "integer",
+          "maximum": 9223372036854775807,
+          "minimum": -9223372036854775807
         },
         "priority_groups": {
           "description": "The state of Priority Groups",


### PR DESCRIPTION
`ConsumerInfo` has `pause_remaining` rather than `paused_until`.
https://github.com/nats-io/nats-server/blob/d0ce4c4ad29d3a363f7865c1e5cf12d345f55297/server/consumer.go#L66

Signed-off-by: Piotr Piotrowski [piotr@synadia.com](mailto:piotr@synadia.com)