### PR TITLE
Fix gathering profiles in `audit` package

### DIFF
--- a/audit/gather/gather.go
+++ b/audit/gather/gather.go
@@ -525,7 +525,7 @@ func (g *gather) captureServerProfiles(serverInfoMap map[string]*server.ServerIn
 				clusterTag,
 			}
 
-			err = g.aw.AddRaw(bytes.NewReader(responseBytes), "prof", tags...)
+			err = g.aw.AddRaw(bytes.NewReader(profileStatus.Profile), "prof", tags...)
 			if err != nil {
 				return fmt.Errorf("failed to add %s profile from to archive: %w", profileName, err)
 			}


### PR DESCRIPTION
If we write `responseBytes` into the archive then we get the full raw JSON of the message rather than the raw profile bytes.

Signed-off-by: Neil Twigg <neil@nats.io>