### PR TITLE
Update archiver to support paged artifact storage

### DIFF
--- a/audit/account_checks_test.go
+++ b/audit/account_checks_test.go
@@ -71,7 +71,8 @@ func TestACCOUNTS_001(t *testing.T) {
 			},
 			map[string]*server.AccountInfo{
 				"SYS": {
-					ClientCnt: 901,
+					AccountName: "SYS",
+					ClientCnt:   901,
 					Claim: &jwt.AccountClaims{
 						Account: jwt.Account{
 							Limits: jwt.OperatorLimits{
@@ -94,7 +95,8 @@ func TestACCOUNTS_001(t *testing.T) {
 			},
 			map[string]*server.AccountInfo{
 				"SYS": {
-					SubCnt: 901,
+					AccountName: "SYS",
+					SubCnt:      901,
 					Claim: &jwt.AccountClaims{
 						Account: jwt.Account{
 							Limits: jwt.OperatorLimits{
@@ -117,8 +119,9 @@ func TestACCOUNTS_001(t *testing.T) {
 			},
 			map[string]*server.AccountInfo{
 				"SYS": {
-					ClientCnt: 100,
-					SubCnt:    100,
+					AccountName: "SYS",
+					ClientCnt:   100,
+					SubCnt:      100,
 					Claim: &jwt.AccountClaims{
 						Account: jwt.Account{
 							Limits: jwt.OperatorLimits{

--- a/audit/archive/README.md
+++ b/audit/archive/README.md
@@ -23,9 +23,9 @@ For example, the capture of a server `VARZ` endpoint may be tagged with:
  - `server:bar_1`
  - `type:server_varz`
 
-A filename for is derived from it's tags, and may look something like:
+Artifact filenames are derived from their tags. For paged artifacts, the files are stored in a dedicated directory with numbered JSON pages:
 ```
-capture/clusters/awseast_bar/bar_1/variables.json
+capture/clusters/awseast_bar/bar_1/variables/0001.json
 ```
 
 In addition to capture artifacts, the archive contains a few special files.
@@ -42,10 +42,17 @@ n.b. Do not rely on path parsing and path conventions, query using the manifest 
 
 n.b.: If a server does not belong to a cluster, then `cluster_name` is `unclustered` for all the paths below.
 
+### Note on paging
+
+Some artifacts (e.g., stream info, health, varz) are stored in **paged format**, split across multiple JSON files (e.g., `0001.json`, `0002.json`, ...), each containing one or more JSON objects.
+
+Other artifacts (e.g., profiles and special files) are stored as **non-paged single files**.
+
+
 ## Server-specific artifacts
 
 
-`${prefix}/clusters/${cluster_name}/${server_name}/${artifact_type}.json`
+`${prefix}/clusters/${cluster_name}/${server_name}/${artifact_type}/0001.json`
 
 Example: snapshot of health endpoint
 
@@ -53,7 +60,7 @@ Example: snapshot of health endpoint
 
 Each account artifact can appear multiple times as it is captured through different servers.
 
-`${prefix}/accounts/${account_name}/servers/${cluster_name}__${server_name}/${artifact_type}.json"`
+`${prefix}/accounts/${account_name}/servers/${cluster_name}__${server_name}/${artifact_type}/0001.json"`
 
 Example: account connections
 
@@ -61,17 +68,21 @@ Example: account connections
 
 Each stream artifact can appear multiple times as it is captured through different replicas.
 
-`${prefix}/accounts/${account_name}/streams/${stream_name}/replicas/${server_name}/${artifact_type}.json`
+`${prefix}/accounts/${account_name}/streams/${stream_name}/replicas/${server_name}/${artifact_type}/0001.json`
 
 Example: stream details
 
 ## Server profiles
+
+Profiles are stored as non-paged files:
 
 `${prefix}/profiles/${cluster_name}/${server_name}__${profile_name}.prof`
 
 Example: memory profile
 
 ## Special files
+
+Special artifacts are stored as flat files and not paged:
 
 In addition to artifacts, each archive contains a few special files.
 

--- a/audit/archive/archive_test.go
+++ b/audit/archive/archive_test.go
@@ -25,6 +25,19 @@ import (
 	"testing"
 )
 
+func expectedPagedFile(t *testing.T, extension string, tags ...*Tag) string {
+	t.Helper()
+	dir, err := dirNameFromTags(tags)
+	if err != nil {
+		t.Fatalf("failed to generate path from tags %+v: %v", tags, err)
+	}
+	return filepath.Join(dir, "0001."+extension)
+}
+
+func expectedSpecialFile(name, extension string) string {
+	return filepath.Join("capture", "misc", name+"."+extension)
+}
+
 func Test_CreateThenReadArchive(t *testing.T) {
 	rng := rand.New(rand.NewSource(123456))
 
@@ -263,41 +276,41 @@ func Test_CreateThenReadArchiveUsingTags(t *testing.T) {
 
 	expectedFilesList := []string{
 		// Server health
-		"capture/clusters/C1/X/health.json",
-		"capture/clusters/C1/Y/health.json",
-		"capture/clusters/C1/Z/health.json",
-		"capture/clusters/C2/A/health.json",
-		"capture/clusters/C2/B/health.json",
-		"capture/clusters/C2/C/health.json",
-		"capture/clusters/C2/D/health.json",
-		"capture/clusters/C2/E/health.json",
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("X"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("Y"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("Z"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("A"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("B"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("C"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("D"), TagServerHealth()),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("E"), TagServerHealth()),
 
 		// Server info
-		"capture/clusters/C1/X/server_info.json",
-		"capture/clusters/C1/Y/server_info.json",
-		"capture/clusters/C1/Z/server_info.json",
-		"capture/clusters/C2/A/server_info.json",
-		"capture/clusters/C2/B/server_info.json",
-		"capture/clusters/C2/C/server_info.json",
-		"capture/clusters/C2/D/server_info.json",
-		"capture/clusters/C2/E/server_info.json",
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("X"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("Y"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("Z"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("A"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("B"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("C"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("D"), TagArtifactType("server_info")),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("E"), TagArtifactType("server_info")),
 
 		// Cluster info
-		"capture/clusters/C1/X/cluster_info.json",
-		"capture/clusters/C2/A/cluster_info.json",
+		expectedPagedFile(t, "json", TagCluster("C1"), TagServer("X"), TagArtifactType("cluster_info")),
+		expectedPagedFile(t, "json", TagCluster("C2"), TagServer("A"), TagArtifactType("cluster_info")),
 
 		// Stream info
-		"capture/accounts/$G/streams/ORDERS/replicas/C2__A/stream_info.json",
-		"capture/accounts/$G/streams/ORDERS/replicas/C2__B/stream_info.json",
-		"capture/accounts/$G/streams/ORDERS/replicas/C2__E/stream_info.json",
+		expectedPagedFile(t, "json", TagAccount("$G"), TagCluster("C2"), TagServer("A"), TagStream("ORDERS"), TagArtifactType("stream_info")),
+		expectedPagedFile(t, "json", TagAccount("$G"), TagCluster("C2"), TagServer("B"), TagStream("ORDERS"), TagArtifactType("stream_info")),
+		expectedPagedFile(t, "json", TagAccount("$G"), TagCluster("C2"), TagServer("E"), TagStream("ORDERS"), TagArtifactType("stream_info")),
 
 		// Account info
-		"capture/accounts/$G/servers/C1__X/account_info.json",
-		"capture/accounts/$G/servers/C1__Y/account_info.json",
-		"capture/accounts/$G/servers/C1__Z/account_info.json",
+		expectedPagedFile(t, "json", TagAccount("$G"), TagCluster("C1"), TagServer("X"), TagArtifactType("account_info")),
+		expectedPagedFile(t, "json", TagAccount("$G"), TagCluster("C1"), TagServer("Y"), TagArtifactType("account_info")),
+		expectedPagedFile(t, "json", TagAccount("$G"), TagCluster("C1"), TagServer("Z"), TagArtifactType("account_info")),
 
 		// Misc
-		"capture/misc/message.txt",
+		expectedSpecialFile("message", "txt"),
 	}
 	expectedArtifactsCount := len(expectedFilesList) + 1 // +1 for manifest
 	if expectedArtifactsCount != ar.rawFilesCount() {

--- a/audit/archive/paged_archive_test.go
+++ b/audit/archive/paged_archive_test.go
@@ -1,0 +1,397 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+type testArchive struct {
+	ZipReader     *zip.Reader
+	FilePath      string
+	Manifest      map[string][]*Tag
+	StreamPages   map[string]bool
+	TotalObjects  int
+	ExpectedNames map[int]string
+}
+
+func newWriterForTest(t *testing.T, ts time.Time) (*Writer, string) {
+	tmpfile := filepath.Join(t.TempDir(), "archive.zip")
+
+	f, err := os.Create(tmpfile)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	w := &Writer{
+		zipWriter:    zip.NewWriter(f),
+		fileWriter:   f,
+		ts:           &ts,
+		manifestMap:  make(map[string][]*Tag),
+		pagedWriters: make(map[string]*pagedWriter),
+	}
+
+	return w, tmpfile
+}
+func testStreamInfo(index int) *api.StreamInfo {
+	return &api.StreamInfo{
+		Config: api.StreamConfig{
+			Name:     fmt.Sprintf("stream-%02d", index),
+			Subjects: []string{fmt.Sprintf("test.%02d", index)},
+			Storage:  api.MemoryStorage,
+		},
+		Created: time.Now().UTC(),
+		State: api.StreamState{
+			Msgs:     100 + uint64(index),
+			Bytes:    2048 + uint64(index),
+			FirstSeq: 1,
+			LastSeq:  100 + uint64(index),
+		},
+	}
+}
+
+func inspectArchive(t *testing.T, zr *zip.Reader, expectedDir string) (map[string]bool, int, map[string][]*Tag) {
+	t.Helper()
+
+	streamPages := map[string]bool{}
+	total := 0
+	var manifest map[string][]*Tag
+
+	for _, f := range zr.File {
+		switch {
+		case strings.HasPrefix(f.Name, expectedDir+"/") && strings.HasSuffix(f.Name, ".json"):
+			streamPages[f.Name] = true
+			rc, _ := f.Open()
+			dec := json.NewDecoder(rc)
+			for dec.More() {
+				var obj map[string]any
+				if err := dec.Decode(&obj); err != nil {
+					t.Errorf("decode failed in %s: %v", f.Name, err)
+				} else {
+					total++
+				}
+			}
+			rc.Close()
+		case f.Name == "capture/misc/manifest.json":
+			rc, _ := f.Open()
+			defer rc.Close()
+			if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+				t.Fatalf("failed to decode manifest: %v", err)
+			}
+		}
+	}
+
+	return streamPages, total, manifest
+}
+
+func buildPagedTestArchive(t *testing.T, totalObjects, objectsPerPage int) *testArchive {
+	t.Helper()
+
+	writer, tmpFile := newWriterForTest(t, time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC))
+	expected := make(map[int]string)
+
+	tags := []*Tag{
+		TagAccount("A"),
+		TagCluster("C"),
+		TagServer("S"),
+		TagStream("TEST_STREAM"),
+		TagStreamInfo(),
+	}
+
+	pageCount := (totalObjects + objectsPerPage - 1) / objectsPerPage
+	for page := 0; page < pageCount; page++ {
+		for i := 0; i < objectsPerPage; i++ {
+			index := page*objectsPerPage + i
+			if index >= totalObjects {
+				break
+			}
+			expected[index] = fmt.Sprintf("stream-%02d", index)
+			if err := writer.Add(testStreamInfo(index), tags...); err != nil {
+				t.Fatalf("Add failed at index %d: %v", index, err)
+			}
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	zipBytes, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read archive file: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		t.Fatalf("failed to open zip reader: %v", err)
+	}
+
+	expectedDir, err := dirNameFromTags(tags)
+	if err != nil {
+		t.Fatalf("failed to resolve expected stream_info dir: %v", err)
+	}
+
+	streamPages, total, manifest := inspectArchive(t, zr, expectedDir)
+
+	return &testArchive{
+		ZipReader:     zr,
+		FilePath:      tmpFile,
+		Manifest:      manifest,
+		StreamPages:   streamPages,
+		TotalObjects:  total,
+		ExpectedNames: expected,
+	}
+}
+
+func TestPagedWriter(t *testing.T) {
+	ta := buildPagedTestArchive(t, 50, 5)
+
+	t.Run("writes multiple paged files to correct nested paths", func(t *testing.T) {
+		if len(ta.StreamPages) < 2 {
+			t.Errorf("expected at least 2 stream_info pages, got %d", len(ta.StreamPages))
+		}
+	})
+
+	t.Run("encodes all entries into paged files", func(t *testing.T) {
+		if ta.TotalObjects != 50 {
+			t.Errorf("expected 50 entries, got %d", ta.TotalObjects)
+		}
+	})
+
+	t.Run("includes manifest.json in archive", func(t *testing.T) {
+		if ta.Manifest == nil {
+			t.Fatal("manifest.json not found in archive")
+		}
+	})
+
+	t.Run("manifest includes correct paths and tags", func(t *testing.T) {
+		tags := []*Tag{
+			TagAccount("A"),
+			TagCluster("C"),
+			TagServer("S"),
+			TagStream("TEST_STREAM"),
+			TagStreamInfo(),
+		}
+		expectedDir, err := dirNameFromTags(tags)
+		if err != nil {
+			t.Fatalf("failed to resolve expected manifest path prefix: %v", err)
+		}
+		expectedPrefix := expectedDir + "/"
+
+		for path, tags := range ta.Manifest {
+			if !strings.HasPrefix(path, expectedPrefix) {
+				t.Errorf("unexpected manifest path: %s, expected prefix: %s", path, expectedPrefix)
+			}
+			found := false
+			for _, tag := range tags {
+				if tag.Name == typeTagLabel && tag.Value == streamDetailsArtifactType {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("manifest entry %s missing stream_info type tag", path)
+			}
+		}
+	})
+
+	t.Run("each stream_info page contains only complete JSON objects", func(t *testing.T) {
+		for page := range ta.StreamPages {
+			rc, err := ta.ZipReader.Open(page)
+			if err != nil {
+				t.Errorf("failed to open page %s: %v", page, err)
+				continue
+			}
+			dec := json.NewDecoder(rc)
+			for dec.More() {
+				var obj map[string]any
+				if err := dec.Decode(&obj); err != nil {
+					t.Errorf("decode failed in %s: %v", page, err)
+				}
+			}
+			rc.Close()
+		}
+	})
+
+	t.Run("addPathToManifest fails on missing type tag", func(t *testing.T) {
+		writer := &Writer{
+			manifestMap: make(map[string][]*Tag),
+		}
+		tags := []*Tag{
+			TagAccount("A"),
+			TagCluster("C"),
+			TagServer("S"),
+			TagStream("TEST_STREAM"),
+		}
+		err := writer.addPathToManifest(1, "json", tags)
+		if err == nil {
+			t.Fatal("expected error due to missing type tag, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing required tag: artifact type") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("addPathToManifest creates expected directory structures", func(t *testing.T) {
+		tests := []struct {
+			name string
+			tags []*Tag
+		}{
+			{"server VARZ", []*Tag{TagCluster("CL1"), TagServer("srvA"), TagServerVars()}},
+			{"account CONNZ", []*Tag{TagAccount("ACC1"), TagCluster("CL2"), TagServer("srvB"), TagAccountConnections()}},
+			{"stream info", []*Tag{TagAccount("ACC2"), TagCluster("CL3"), TagServer("srvC"), TagStream("mystream"), TagStreamInfo()}},
+			{"profile", []*Tag{TagCluster("CL4"), TagServer("srvD"), TagServerProfile(), TagProfileName("cpu")}},
+			{"special metadata", []*Tag{TagSpecial("audit_metadata")}},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				w := &Writer{manifestMap: make(map[string][]*Tag)}
+				err := w.addPathToManifest(0, "json", tt.tags)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				var actualPath string
+				for key := range w.manifestMap {
+					if isNonPagedArtifact(tt.tags) {
+						actualPath = strings.TrimSuffix(key, filepath.Ext(key))
+					} else {
+						actualPath = filepath.Dir(key)
+					}
+					break
+				}
+				expectedDir, err := dirNameFromTags(tt.tags)
+				if err != nil {
+					t.Fatalf("failed to resolve expected path: %v", err)
+				}
+				if actualPath != expectedDir {
+					t.Errorf("expected path %q, got %q", expectedDir, actualPath)
+				}
+			})
+		}
+	})
+
+	t.Run("verifies decompressed size and counts all non-manifest files", func(t *testing.T) {
+		var totalSize int64
+		var counted int
+		for _, f := range ta.ZipReader.File {
+			if strings.HasSuffix(f.Name, "manifest.json") {
+				continue
+			}
+			counted++
+			totalSize += int64(f.UncompressedSize64)
+		}
+		if counted != 50 {
+			t.Errorf("expected 50 files, got %d", counted)
+		}
+		const minExpectedSize = 10_000
+		if totalSize < minExpectedSize {
+			t.Errorf("uncompressed size %d bytes is smaller than expected size %d bytes", totalSize, minExpectedSize)
+		}
+	})
+}
+
+func TestPagedReader(t *testing.T) {
+	ta := buildPagedTestArchive(t, 50, 5)
+
+	reader, err := NewReader(ta.FilePath)
+	if err != nil {
+		t.Fatalf("failed to create archive reader: %v", err)
+	}
+
+	t.Run("iterates all *api.StreamInfo entries", func(t *testing.T) {
+		count := 0
+		err := ForEachTaggedArtifact(reader, []*Tag{TagAccount("A"), TagCluster("C"), TagServer("S"), TagStream("TEST_STREAM"), TagStreamInfo()}, func(entry *api.StreamInfo) error {
+			count++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("EachPagedByTags failed: %v", err)
+		}
+		if count != len(ta.ExpectedNames) {
+			t.Errorf("expected %d entries, got %d", len(ta.ExpectedNames), count)
+		}
+	})
+
+	t.Run("stops early when callback returns error", func(t *testing.T) {
+		count := 0
+		err := ForEachTaggedArtifact(reader, []*Tag{TagAccount("A"), TagCluster("C"), TagServer("S"), TagStream("TEST_STREAM"), TagStreamInfo()}, func(entry *api.StreamInfo) error {
+			count++
+			if count == 5 {
+				return fmt.Errorf("stop here")
+			}
+			return nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "stop here") {
+			t.Errorf("expected error 'stop here', got %v", err)
+		}
+		if count != 5 {
+			t.Errorf("expected early exit at 5, got %d", count)
+		}
+	})
+
+	t.Run("verifies *api.StreamInfo object content", func(t *testing.T) {
+		seen := map[int]string{}
+
+		err := ForEachTaggedArtifact(reader, []*Tag{TagAccount("A"), TagCluster("C"), TagServer("S"), TagStream("TEST_STREAM"), TagStreamInfo()}, func(info *api.StreamInfo) error {
+			var i int
+			if _, err := fmt.Sscanf(info.Config.Name, "stream-%02d", &i); err != nil {
+				t.Errorf("invalid stream name: %q", info.Config.Name)
+				return nil
+			}
+			seen[i] = info.Config.Name
+
+			if info.State.Msgs < 100 {
+				t.Errorf("stream %q has too few messages", info.Config.Name)
+			}
+			return nil
+		})
+
+		if err != nil {
+			t.Fatalf("EachPagedByTags failed: %v", err)
+		}
+
+		if len(seen) != len(ta.ExpectedNames) {
+			t.Errorf("expected %d entries, got %d", len(ta.ExpectedNames), len(seen))
+		}
+
+		for i, want := range ta.ExpectedNames {
+			if got := seen[i]; got != want {
+				t.Errorf("entry %d: got %q, want %q", i, got, want)
+			}
+		}
+	})
+
+	t.Run("EachClusterServerArtifact iterates all expected entries", func(t *testing.T) {
+		expectedCluster := "C"
+		expectedServer := "S"
+		expectedCount := len(ta.ExpectedNames)
+
+		count := 0
+		count, err := EachClusterServerArtifact(reader, TagStreamInfo(), func(clusterTag *Tag, serverTag *Tag, err error, artifact *api.StreamInfo) error {
+			if err != nil {
+				t.Errorf("unexpected error for %s/%s: %v", clusterTag.Value, serverTag.Value, err)
+				return nil
+			}
+			if clusterTag.Value != expectedCluster || serverTag.Value != expectedServer {
+				t.Errorf("unexpected cluster/server: %s/%s", clusterTag.Value, serverTag.Value)
+			}
+			count++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("EachClusterServerArtifact failed: %v", err)
+		}
+		if count != expectedCount {
+			t.Errorf("expected %d entries, got %d", expectedCount, count)
+		}
+	})
+
+}

--- a/audit/archive/paged_writer.go
+++ b/audit/archive/paged_writer.go
@@ -1,0 +1,57 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"time"
+)
+
+// pagedWriter writes JSON entries to paged files inside the zip archive.
+type pagedWriter struct {
+	zipWriter *zip.Writer
+	dir       string
+	buf       *bytes.Buffer
+	pageIndex int
+	ts        *time.Time
+}
+
+func newPagedWriter(z *zip.Writer, dir string, ts *time.Time) *pagedWriter {
+	return &pagedWriter{
+		zipWriter: z,
+		dir:       dir,
+		buf:       &bytes.Buffer{},
+		pageIndex: 1,
+		ts:        ts,
+	}
+}
+
+func (pw *pagedWriter) WriteEntry(r io.Reader) error {
+	filename := filepath.Join(pw.dir, fmt.Sprintf("%04d.json", pw.pageIndex))
+	header := &zip.FileHeader{
+		Name:     filename,
+		Method:   zip.Deflate,
+		Modified: tsToUTC(pw.ts),
+	}
+
+	w, err := pw.zipWriter.CreateHeader(header)
+	if err != nil {
+		return fmt.Errorf("failed to create zip entry: %w", err)
+	}
+
+	if _, err := io.Copy(w, r); err != nil {
+		return fmt.Errorf("failed to write zip entry: %w", err)
+	}
+
+	pw.pageIndex++
+	return nil
+}
+
+func tsToUTC(ts *time.Time) time.Time {
+	if ts != nil {
+		return ts.UTC()
+	}
+	return time.Now().UTC()
+}

--- a/audit/archive/tag.go
+++ b/audit/archive/tag.go
@@ -16,6 +16,8 @@ package archive
 import (
 	"fmt"
 	"path"
+	"path/filepath"
+	"strings"
 )
 
 type TagLabel string
@@ -210,6 +212,18 @@ func createFilenameFromTags(extension string, tags []*Tag) (string, error) {
 
 	// May add more cases later, for now bomb if none of the above applies
 	return "", fmt.Errorf("unhandled tags combination: %+v", dimensionTagsMap)
+}
+
+func dirNameFromTags(tags []*Tag) (string, error) {
+	fullPath, err := createFilenameFromTags("json", tags)
+	if err != nil {
+		return "", err
+	}
+
+	base := filepath.Base(fullPath)
+	artifactDir := strings.TrimSuffix(base, filepath.Ext(base))
+	parent := filepath.Dir(fullPath)
+	return filepath.Join(parent, artifactDir), nil
 }
 
 func TagArtifactType(artifactType string) *Tag {


### PR DESCRIPTION
This changes how artifacts are stored in the archive, switching from a single artifact.json file to paged JSON files like .../artifact/0001.json. Profile data and special files (e.g., logs) still use the original single-file format, as paging doesn't apply.

Paged API requests have been implemented for the CONNZ, SUBSZ, and JSZ server endpoints. More endpoints can be supported as they gain pagination support.

Audit checks have been updated to iterate over paged data using the new Reader methods.