### PR TITLE
Ensure next_for subject is always set

### DIFF
--- a/stream_pager.go
+++ b/stream_pager.go
@@ -86,6 +86,7 @@ func (p *StreamPager) start(stream *Stream, mgr *Manager, opts ...PagerOption) e
 	p.startDelta = 0
 	p.startSeq = -1
 	p.seen = -1
+	p.filterSubject = ">"
 
 	for _, o := range opts {
 		o(p)


### PR DESCRIPTION
Without this, when there is no filter set, the request will only ask for a given seq due to the omitempty

So any gap in the messages will terminate the viewer.