### PR TITLE
Align with the needs of go 1.24 go vet

### DIFF
--- a/monitor/credentials.go
+++ b/monitor/credentials.go
@@ -36,7 +36,7 @@ type CheckCredentialOptions struct {
 func CheckCredential(check *Result, opts CheckCredentialOptions) error {
 	ok, err := fileAccessible(opts.File)
 	if err != nil {
-		check.Critical("credential not accessible: %v", err)
+		check.Criticalf("credential not accessible: %v", err)
 		return nil
 	}
 
@@ -47,19 +47,19 @@ func CheckCredential(check *Result, opts CheckCredentialOptions) error {
 
 	cb, err := os.ReadFile(opts.File)
 	if err != nil {
-		check.Critical("credential not accessible: %v", err)
+		check.Criticalf("credential not accessible: %v", err)
 		return nil
 	}
 
 	token, err := nkeys.ParseDecoratedJWT(cb)
 	if err != nil {
-		check.Critical("invalid credential: %v", err)
+		check.Criticalf("invalid credential: %v", err)
 		return nil
 	}
 
 	claims, err := jwt.Decode(token)
 	if err != nil {
-		check.Critical("invalid credential: %v", err)
+		check.Criticalf("invalid credential: %v", err)
 	}
 
 	now := time.Now().UTC().Unix()
@@ -74,11 +74,11 @@ func CheckCredential(check *Result, opts CheckCredentialOptions) error {
 	case cd.Expires == 0 && opts.RequiresExpiry:
 		check.Critical("never expires")
 	case opts.ValidityCritical > 0 && (until <= crit):
-		check.Critical("expires sooner than %s", f(secondsToDuration(opts.ValidityCritical)))
+		check.Criticalf("expires sooner than %s", f(secondsToDuration(opts.ValidityCritical)))
 	case opts.ValidityWarning > 0 && (until <= warn):
-		check.Warn("expires sooner than %s", f(secondsToDuration(opts.ValidityWarning)))
+		check.Warnf("expires sooner than %s", f(secondsToDuration(opts.ValidityWarning)))
 	default:
-		check.Ok("expires in %s", time.Unix(cd.Expires, 0).UTC())
+		check.Okf("expires in %s", time.Unix(cd.Expires, 0).UTC())
 	}
 
 	return nil

--- a/monitor/kv.go
+++ b/monitor/kv.go
@@ -33,23 +33,23 @@ type CheckKVBucketAndKeyOptions struct {
 
 func CheckKVBucketAndKeyWithConnection(nc *nats.Conn, check *Result, opts CheckKVBucketAndKeyOptions) error {
 	js, err := nc.JetStream()
-	if check.CriticalIfErr(err, "connection failed: %v", err) {
+	if check.CriticalIfErrf(err, "connection failed: %v", err) {
 		return nil
 	}
 
 	kv, err := js.KeyValue(opts.Bucket)
 	if errors.Is(err, nats.ErrBucketNotFound) {
-		check.Critical("bucket %v not found", opts.Bucket)
+		check.Criticalf("bucket %v not found", opts.Bucket)
 		return nil
 	} else if err != nil {
-		check.Critical("could not load bucket: %v", err)
+		check.Criticalf("could not load bucket: %v", err)
 		return nil
 	}
 
-	check.Ok("bucket %s", opts.Bucket)
+	check.Okf("bucket %s", opts.Bucket)
 
 	status, err := kv.Status()
-	if check.CriticalIfErr(err, "could not obtain bucket status: %v", err) {
+	if check.CriticalIfErrf(err, "could not obtain bucket status: %v", err) {
 		return nil
 	}
 
@@ -60,19 +60,19 @@ func CheckKVBucketAndKeyWithConnection(nc *nats.Conn, check *Result, opts CheckK
 	if opts.Key != "" {
 		v, err := kv.Get(opts.Key)
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			check.Critical("key %s not found", opts.Key)
+			check.Criticalf("key %s not found", opts.Key)
 		} else if err != nil {
-			check.Critical("key %s not loaded: %v", opts.Key, err)
+			check.Criticalf("key %s not loaded: %v", opts.Key, err)
 		} else {
 			switch v.Operation() {
 			case nats.KeyValueDelete:
-				check.Critical("key %v is deleted", opts.Key)
+				check.Criticalf("key %v is deleted", opts.Key)
 			case nats.KeyValuePurge:
-				check.Critical("key %v is purged", opts.Key)
+				check.Criticalf("key %v is purged", opts.Key)
 			case nats.KeyValuePut:
-				check.Ok("key %s found", opts.Key)
+				check.Okf("key %s found", opts.Key)
 			default:
-				check.Critical("unknown key operation for %s: %v", opts.Key, v.Operation())
+				check.Criticalf("unknown key operation for %s: %v", opts.Key, v.Operation())
 			}
 		}
 	}
@@ -80,19 +80,19 @@ func CheckKVBucketAndKeyWithConnection(nc *nats.Conn, check *Result, opts CheckK
 	if opts.ValuesWarning > -1 || opts.ValuesCritical > -1 {
 		if opts.ValuesCritical < opts.ValuesWarning {
 			if opts.ValuesCritical > -1 && status.Values() <= uint64(opts.ValuesCritical) {
-				check.Critical("%d values", status.Values())
+				check.Criticalf("%d values", status.Values())
 			} else if opts.ValuesWarning > -1 && status.Values() <= uint64(opts.ValuesWarning) {
-				check.Warn("%d values", status.Values())
+				check.Warnf("%d values", status.Values())
 			} else {
-				check.Ok("%d values", status.Values())
+				check.Okf("%d values", status.Values())
 			}
 		} else {
 			if opts.ValuesCritical > -1 && status.Values() >= uint64(opts.ValuesCritical) {
-				check.Critical("%d values", status.Values())
+				check.Criticalf("%d values", status.Values())
 			} else if opts.ValuesWarning > -1 && status.Values() >= uint64(opts.ValuesWarning) {
-				check.Warn("%d values", status.Values())
+				check.Warnf("%d values", status.Values())
 			} else {
-				check.Ok("%d values", status.Values())
+				check.Okf("%d values", status.Values())
 			}
 		}
 	}
@@ -110,7 +110,7 @@ func CheckKVBucketAndKeyWithConnection(nc *nats.Conn, check *Result, opts CheckK
 
 func CheckKVBucketAndKey(server string, nopts []nats.Option, check *Result, opts CheckKVBucketAndKeyOptions) error {
 	nc, err := nats.Connect(server, nopts...)
-	if check.CriticalIfErr(err, "connection failed: %v", err) {
+	if check.CriticalIfErrf(err, "connection failed: %v", err) {
 		return nil
 	}
 	defer nc.Close()

--- a/monitor/result.go
+++ b/monitor/result.go
@@ -58,45 +58,88 @@ func (r *Result) Pd(pd ...*PerfDataItem) {
 	r.PerfData = append(r.PerfData, pd...)
 }
 
-func (r *Result) CriticalExit(format string, a ...any) {
-	r.Critical(format, a...)
+func (r *Result) CriticalExit(msg string) {
+	r.Critical(msg)
 	r.GenericExit()
 }
 
-func (r *Result) Critical(format string, a ...any) {
+func (r *Result) CriticalExitf(format string, a ...any) {
+	r.Criticalf(format, a...)
+	r.GenericExit()
+}
+
+func (r *Result) Critical(msg string) {
+	r.Criticals = append(r.Criticals, msg)
+}
+
+func (r *Result) Criticalf(format string, a ...any) {
 	r.Criticals = append(r.Criticals, fmt.Sprintf(format, a...))
 }
 
-func (r *Result) Warn(format string, a ...any) {
+func (r *Result) Warn(msg string) {
+	r.Warnings = append(r.Warnings, msg)
+}
+
+func (r *Result) Warnf(format string, a ...any) {
 	r.Warnings = append(r.Warnings, fmt.Sprintf(format, a...))
 }
 
-func (r *Result) Ok(format string, a ...any) {
+func (r *Result) Ok(msg string) {
+	r.OKs = append(r.OKs, msg)
+}
+
+func (r *Result) Okf(format string, a ...any) {
 	r.OKs = append(r.OKs, fmt.Sprintf(format, a...))
 }
 
-func (r *Result) OkIfNoWarningsOrCriticals(format string, a ...any) {
+func (r *Result) OkIfNoWarningsOrCriticals(msg string) {
 	if len(r.Warnings) == 0 && len(r.Criticals) == 0 {
-		r.Ok(format, a...)
+		r.Ok(msg)
 	}
 }
 
-func (r *Result) CriticalExitIfErr(err error, format string, a ...any) bool {
+func (r *Result) OkIfNoWarningsOrCriticalsf(format string, a ...any) {
+	if len(r.Warnings) == 0 && len(r.Criticals) == 0 {
+		r.Okf(format, a...)
+	}
+}
+
+func (r *Result) CriticalExitIfErrf(err error, format string, a ...any) bool {
 	if err == nil {
 		return false
 	}
 
-	r.CriticalExit(format, a...)
+	r.CriticalExitf(format, a...)
 
 	return true
 }
 
-func (r *Result) CriticalIfErr(err error, format string, a ...any) bool {
+func (r *Result) CriticalExitIfErr(err error, msg string) bool {
 	if err == nil {
 		return false
 	}
 
-	r.Critical(format, a...)
+	r.CriticalExit(msg)
+
+	return true
+}
+
+func (r *Result) CriticalIfErr(err error, msg string) bool {
+	if err == nil {
+		return false
+	}
+
+	r.Critical(msg)
+
+	return true
+}
+
+func (r *Result) CriticalIfErrf(err error, format string, a ...any) bool {
+	if err == nil {
+		return false
+	}
+
+	r.Criticalf(format, a...)
 
 	return true
 }
@@ -314,7 +357,7 @@ func (r *Result) GenericExit() {
 	// so we try to add some flavor here at least
 	err := recover()
 	if err != nil {
-		r.Critical("check caused a panic: %v", err)
+		r.Criticalf("check caused a panic: %v", err)
 		if r.Trace {
 			debug.PrintStack()
 		}

--- a/monitor/server.go
+++ b/monitor/server.go
@@ -62,7 +62,7 @@ func CheckServer(server string, nopts []nats.Option, check *Result, timeout time
 
 	if opts.Resolver == nil {
 		nc, err = nats.Connect(server, nopts...)
-		if check.CriticalIfErr(err, "connection failed: %v", err) {
+		if check.CriticalIfErrf(err, "connection failed: %v", err) {
 			return nil
 		}
 		defer nc.Close()
@@ -79,56 +79,56 @@ func CheckServerWithConnection(nc *nats.Conn, check *Result, timeout time.Durati
 	}
 
 	vz, err := opts.Resolver(nc, opts.Name, timeout)
-	if check.CriticalIfErr(err, "varz failed: %v", err) {
+	if check.CriticalIfErrf(err, "varz failed: %v", err) {
 		return nil
 	}
 
 	if vz == nil {
-		check.Critical("no data received")
+		check.Criticalf("no data received")
 		return nil
 	}
 
 	if vz.Name != opts.Name {
-		check.Critical("result from wrong server %q", vz.Name)
+		check.Criticalf("result from wrong server %q", vz.Name)
 	}
 
 	if opts.JetStreamRequired {
 		if vz.JetStream.Config == nil {
-			check.Critical("JetStream not enabled")
+			check.Criticalf("JetStream not enabled")
 		} else {
-			check.Ok("JetStream enabled")
+			check.Okf("JetStream enabled")
 		}
 	}
 
 	if opts.TLSRequired {
 		if vz.TLSRequired {
-			check.Ok("TLS required")
+			check.Okf("TLS required")
 		} else {
-			check.Critical("TLS not required")
+			check.Criticalf("TLS not required")
 		}
 	}
 
 	if opts.AuthenticationRequired {
 		if vz.AuthRequired {
-			check.Ok("Authentication required")
+			check.Okf("Authentication required")
 		} else {
-			check.Critical("Authentication not required")
+			check.Criticalf("Authentication not required")
 		}
 	}
 
 	up := vz.Now.Sub(vz.Start)
 	if opts.UptimeWarning > 0 || opts.UptimeCritical > 0 {
 		if opts.UptimeCritical > opts.UptimeWarning {
-			check.Critical("Up invalid thresholds")
+			check.Criticalf("Up invalid thresholds")
 			return nil
 		}
 
 		if up <= secondsToDuration(opts.UptimeCritical) {
-			check.Critical("Up %s", f(up))
+			check.Criticalf("Up %s", f(up))
 		} else if up <= secondsToDuration(opts.UptimeWarning) {
-			check.Warn("Up %s", f(up))
+			check.Warnf("Up %s", f(up))
 		} else {
-			check.Ok("Up %s", f(up))
+			check.Okf("Up %s", f(up))
 		}
 	}
 
@@ -146,25 +146,25 @@ func CheckServerWithConnection(nc *nats.Conn, check *Result, timeout time.Durati
 		}
 
 		if !r && crit < warn {
-			check.Critical("%s invalid thresholds", name)
+			check.Criticalf("%s invalid thresholds", name)
 			return
 		}
 
 		if r && crit < warn {
 			if value <= crit {
-				check.Critical("%s %.2f", name, value)
+				check.Criticalf("%s %.2f", name, value)
 			} else if value <= warn {
-				check.Warn("%s %.2f", name, value)
+				check.Warnf("%s %.2f", name, value)
 			} else {
-				check.Ok("%s %.2f", name, value)
+				check.Okf("%s %.2f", name, value)
 			}
 		} else {
 			if value >= crit {
-				check.Critical("%s %.2f", name, value)
+				check.Criticalf("%s %.2f", name, value)
 			} else if value >= warn {
-				check.Warn("%s %.2f", name, value)
+				check.Warnf("%s %.2f", name, value)
 			} else {
-				check.Ok("%s %.2f", name, value)
+				check.Okf("%s %.2f", name, value)
 			}
 		}
 	}


### PR DESCRIPTION
It naively checks anything with a printf style arguments and complains when passed only one argument, even if no alternative exist.

It also only support turning the check off for the entire codebase not just some lines, so we just have to play along