### PR TITLE
Make 2.12 new fields omit empty

### DIFF
--- a/api/streams.go
+++ b/api/streams.go
@@ -597,9 +597,9 @@ type StreamConfig struct {
 	// these properties may have
 	ConsumerLimits StreamConsumerLimits `json:"consumer_limits" yaml:"consumer_limits"`
 	// AllowAtomicPublish allows atomic batch publishing into the stream.
-	AllowAtomicPublish bool `json:"allow_atomic" yaml:"allow_atomic"`
+	AllowAtomicPublish bool `json:"allow_atomic,omitempty" yaml:"allow_atomic"`
 	// AllowMsgCounter allows a stream to use (only) counter CRDTs.
-	AllowMsgCounter bool `json:"allow_msg_counter" yaml:"allow_msg_counter"`
+	AllowMsgCounter bool `json:"allow_msg_counter,omitempty" yaml:"allow_msg_counter"`
 }
 
 // StreamConsumerLimits describes limits and defaults for consumers created on a stream


### PR DESCRIPTION
With strict loading of JSON these would fail to load on 2.11 even if not in use