### PR TITLE
Human-readable format for audit archive file

### DIFF
--- a/audit/gather/gather.go
+++ b/audit/gather/gather.go
@@ -163,7 +163,7 @@ func (g *gather) start() error {
 	ts := time.Now().UTC()
 
 	if g.cfg.TargetPath == "" {
-		g.cfg.TargetPath = filepath.Join(os.TempDir(), fmt.Sprintf("audit-archive-%d.zip", ts.Unix()))
+		g.cfg.TargetPath = filepath.Join(os.TempDir(), fmt.Sprintf("audit-archive-%s.zip", ts.Format("2006-01-02T15-04-05Z")))
 	}
 	target := g.cfg.TargetPath
 


### PR DESCRIPTION
I am unsure if there is a reason to use Unix time in a file name. 
If not, can we use a human-readable filename?
```
# go run . -- audit gather

Archive created at: /tmp/audit-archive-2025-08-18T22-31-40Z.zip
```
This format doesn't include `:`, so is safe on Windows^

That would be easier to work with, than this:
```
# ls -1 audit-archive-175371*
audit-archive-1753716962.zip
audit-archive-1753717145.zip
audit-archive-1753718273.zip
```