### PR TITLE
Support offline assets

### DIFF
--- a/api/consumers.go
+++ b/api/consumers.go
@@ -156,8 +156,9 @@ type JSApiConsumerListRequest struct {
 type JSApiConsumerListResponse struct {
 	JSApiResponse
 	JSApiIterableResponse
-	Consumers []*ConsumerInfo `json:"consumers"`
-	Missing   []string        `json:"missing,omitempty"`
+	Consumers []*ConsumerInfo   `json:"consumers"`
+	Missing   []string          `json:"missing,omitempty"`
+	Offline   map[string]string `json:"offline,omitempty"`
 }
 
 // io.nats.jetstream.api.v1.consumer_leader_stepdown_request

--- a/api/streams.go
+++ b/api/streams.go
@@ -107,8 +107,9 @@ type JSApiStreamNamesResponse struct {
 type JSApiStreamListResponse struct {
 	JSApiResponse
 	JSApiIterableResponse
-	Streams []*StreamInfo `json:"streams"`
-	Missing []string      `json:"missing,omitempty"`
+	Streams []*StreamInfo     `json:"streams"`
+	Missing []string          `json:"missing,omitempty"`
+	Offline map[string]string `json:"offline,omitempty"`
 }
 
 // io.nats.jetstream.api.v1.stream_list_request

--- a/schema_source/jetstream/api/v1/consumer_list_response.json
+++ b/schema_source/jetstream/api/v1/consumer_list_response.json
@@ -29,6 +29,13 @@
             "type": "array",
             "items": {
               "type": "string"
+            },
+            "offline": {
+              "description": "List of streams that are offline and reasons for being offline",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         }

--- a/schema_source/jetstream/api/v1/stream_list_response.json
+++ b/schema_source/jetstream/api/v1/stream_list_response.json
@@ -31,6 +31,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "offline": {
+          "description": "List of streams that are offline and reasons for being offline",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     }

--- a/schemas/jetstream/api/v1/consumer_list_response.json
+++ b/schemas/jetstream/api/v1/consumer_list_response.json
@@ -650,6 +650,13 @@
             "type": "array",
             "items": {
               "type": "string"
+            },
+            "offline": {
+              "description": "List of streams that are offline and reasons for being offline",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         }

--- a/schemas/jetstream/api/v1/stream_list_response.json
+++ b/schemas/jetstream/api/v1/stream_list_response.json
@@ -972,6 +972,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "offline": {
+          "description": "List of streams that are offline and reasons for being offline",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION
Offline assets will appear in the existing "missing" list for older tools and newer tools can access reasons in the new offline fields.

Stream info will error.

Supports https://github.com/nats-io/nats-server/pull/7158