### PR TITLE
Auto setting of js api level header

### DIFF
--- a/api/jetstream_test.go
+++ b/api/jetstream_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+)
+
+func TestRequiredApiLevel(t *testing.T) {
+	// a nested struct has a setting that requires a level 2 api
+	req := &JSApiStreamCreateRequest{
+		StreamConfig: StreamConfig{
+			AllowMsgCounter: true,
+		},
+	}
+	v, err := RequiredApiLevel(req)
+	checkErr(t, err, "RequiredApiLevel failed")
+	if v != 2 {
+		t.Fatalf("expected level 2 got %v", v)
+	}
+
+	// here we use level 1 features
+	creq := &JSApiConsumerCreateRequest{
+		Config: ConsumerConfig{
+			PriorityGroups: []string{"X"},
+			PriorityPolicy: PriorityOverflow,
+		},
+	}
+	v, err = RequiredApiLevel(creq)
+	checkErr(t, err, "RequiredApiLevel failed")
+	if v != 1 {
+		t.Fatalf("expected level 1 got %v", v)
+	}
+
+	// here we set the generally level 1 feature to a value thats unique to 2
+	// and so the consumer specific leveler should have been called to force this to 2
+	creq = &JSApiConsumerCreateRequest{
+		Config: ConsumerConfig{
+			PriorityGroups: []string{"X"},
+			PriorityPolicy: PriorityPrioritized,
+		},
+	}
+	v, err = RequiredApiLevel(creq)
+	checkErr(t, err, "RequiredApiLevel failed")
+	if v != 2 {
+		t.Fatalf("expected level 2 got %v", v)
+	}
+
+	// here we detect invalid tags
+	type invalidTags struct {
+		X string `api_level:"a"`
+	}
+	_, err = RequiredApiLevel(invalidTags{X: "y"})
+	if err.Error() != `invalid api_level tag "a" for field X on type invalidTags` {
+		t.Fatalf("invalid error: %v", err)
+	}
+}

--- a/api/streams.go
+++ b/api/streams.go
@@ -590,19 +590,19 @@ type StreamConfig struct {
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata"`
 	// AllowMsgTTL allows header initiated per-message TTLs. If disabled,
 	// then the `NATS-TTL` header will be ignored.
-	AllowMsgTTL bool `json:"allow_msg_ttl,omitempty" yaml:"allow_msg_ttl"`
+	AllowMsgTTL bool `json:"allow_msg_ttl,omitempty" yaml:"allow_msg_ttl" api_level:"1"`
 	// SubjectDeleteMarkerTTL enables and sets a duration for adding server markers for delete, purge and max age limits
-	SubjectDeleteMarkerTTL time.Duration `json:"subject_delete_marker_ttl,omitempty" yaml:"subject_delete_marker_ttl"`
+	SubjectDeleteMarkerTTL time.Duration `json:"subject_delete_marker_ttl,omitempty" yaml:"subject_delete_marker_ttl" api_level:"1"`
 	// The following defaults will apply to consumers when created against
 	// this stream, unless overridden manually. They also represent the maximum values that
 	// these properties may have
 	ConsumerLimits StreamConsumerLimits `json:"consumer_limits" yaml:"consumer_limits"`
 	// AllowAtomicPublish allows atomic batch publishing into the stream.
-	AllowAtomicPublish bool `json:"allow_atomic,omitempty" yaml:"allow_atomic"`
+	AllowAtomicPublish bool `json:"allow_atomic,omitempty" yaml:"allow_atomic" api_level:"2"`
 	// AllowMsgCounter allows a stream to use (only) counter CRDTs.
-	AllowMsgCounter bool `json:"allow_msg_counter,omitempty" yaml:"allow_msg_counter"`
+	AllowMsgCounter bool `json:"allow_msg_counter,omitempty" yaml:"allow_msg_counter" api_level:"2"`
 	// AllowMsgSchedules allows the scheduling of messages.
-	AllowMsgSchedules bool `json:"allow_msg_schedules,omitempty" yaml:"allow_msg_schedules"`
+	AllowMsgSchedules bool `json:"allow_msg_schedules,omitempty" yaml:"allow_msg_schedules" api_level:"2"`
 }
 
 // StreamConsumerLimits describes limits and defaults for consumers created on a stream

--- a/consumers.go
+++ b/consumers.go
@@ -629,6 +629,21 @@ func PauseUntil(deadline time.Time) ConsumerOption {
 	}
 }
 
+// PrioritizedPriorityGroups sets the consumer to be a prioritized priority consumer with a certain list of groups. When groups is empty the 'none' policy is set
+func PrioritizedPriorityGroups(groups ...string) ConsumerOption {
+	return func(o *api.ConsumerConfig) error {
+		if len(groups) == 0 {
+			o.PriorityGroups = []string{}
+			o.PriorityPolicy = api.PriorityNone
+			return nil
+		}
+
+		o.PriorityPolicy = api.PriorityPrioritized
+		o.PriorityGroups = groups
+		return nil
+	}
+}
+
 // PinnedClientPriorityGroups sets the consumer to be a pinned client priority consumer with a certain list of groups. When groups is empty the 'none' policy is set
 func PinnedClientPriorityGroups(ttl time.Duration, groups ...string) ConsumerOption {
 	return func(o *api.ConsumerConfig) error {
@@ -767,7 +782,7 @@ func (m *Manager) NextMsg(stream string, consumer string) (*nats.Msg, error) {
 		return nil, err
 	}
 
-	return m.request(s, rj)
+	return m.request(s, rj, nil)
 }
 
 // NextMsgRequest creates a request for a batch of messages on a consumer, data or control flow messages will be sent to inbox
@@ -801,7 +816,7 @@ func (m *Manager) NextMsgContext(ctx context.Context, stream string, consumer st
 		return nil, err
 	}
 
-	return m.requestWithContext(ctx, s, []byte(strconv.Itoa(1)))
+	return m.requestWithContext(ctx, s, []byte(strconv.Itoa(1)), nil)
 }
 
 // NextMsgRequest creates a request for a batch of messages, data or control flow messages will be sent to inbox

--- a/test/api_level_test.go
+++ b/test/api_level_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/jsm.go/api"
+)
+
+func TestApiLevelDetection(t *testing.T) {
+	req := api.JSApiConsumerCreateRequest{
+		Config: api.ConsumerConfig{
+			PriorityGroups: []string{"a"},
+			PriorityPolicy: api.PriorityPinnedClient,
+		},
+	}
+
+	lvl, err := api.RequiredApiLevel(req)
+	checkErr(t, err, "failed to determine level")
+	if lvl != 1 {
+		t.Fatalf("expected api level 1 but got %d", lvl)
+	}
+
+	req.Config.PriorityPolicy = api.PriorityPrioritized
+	lvl, err = api.RequiredApiLevel(req)
+	checkErr(t, err, "failed to determine level")
+	if lvl != 2 {
+		t.Fatalf("expected api level 2 but got %d", lvl)
+	}
+
+	srv, nc, mgr := startJSServer(t)
+	defer srv.Shutdown()
+	defer nc.Close()
+
+	s, err := mgr.NewStreamFromDefault("TEST", api.StreamConfig{}, jsm.Subjects("test.*"))
+	checkErr(t, err, "create failed")
+
+	sub, err := nc.SubscribeSync("$JS.API.CONSUMER.CREATE.>")
+	checkErr(t, err, "create failed")
+
+	_, err = s.NewConsumer(jsm.PrioritizedPriorityGroups("foo"))
+	checkErr(t, err, "create failed")
+
+	msg, err := sub.NextMsg(time.Second)
+	checkErr(t, err, "next failed")
+
+	v := msg.Header.Get(api.JSRequiredApiLevel)
+	if v != "2" {
+		t.Fatalf("expected api level 2 but got %s", v)
+	}
+
+	_, err = s.NewConsumer(jsm.PinnedClientPriorityGroups(time.Minute, "foo"))
+	checkErr(t, err, "create failed")
+
+	msg, err = sub.NextMsg(time.Second)
+	checkErr(t, err, "next failed")
+
+	v = msg.Header.Get(api.JSRequiredApiLevel)
+	if v != "1" {
+		t.Fatalf("expected api level 1 but got %s", v)
+	}
+
+	_, err = s.NewConsumer()
+	checkErr(t, err, "create failed")
+
+	msg, err = sub.NextMsg(time.Second)
+	checkErr(t, err, "next failed")
+
+	v = msg.Header.Get(api.JSRequiredApiLevel)
+	if v != "" {
+		t.Fatalf("expected no api level but got %s", v)
+	}
+
+}


### PR DESCRIPTION
This is a POC that marks up structures with api_level="2" tags and tooling to automatically check all requests recursively and determine the highest required api level.

This is then used in setting the Nats-Required-Api-Level automatically for any caller