### PR TITLE
Add user jwt support on connect

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -378,6 +378,15 @@ func (c *Context) NATSOptions(opts ...nats.Option) ([]nats.Option, error) {
 		}
 
 		nopts = append(nopts, nko)
+
+	case c.UserJWT() != "":
+		userCB := func() (string, error) {
+			return c.UserJWT(), nil
+		}
+		sigCB := func(nonce []byte) ([]byte, error) {
+			return nil, nil
+		}
+		nopts = append(nopts, nats.UserJWT(userCB, sigCB))
 	}
 
 	if c.Token() != "" {


### PR DESCRIPTION
I went to add support for the a bearer JWT in the CLI and realized that although field is available in `natscontext`, it wasn't actually be passed as an option on connect.

Once this is merged, I will follow-up with the CLI PR.