### PR TITLE
Do not collect allocs profile

### DIFF
--- a/audit/gather/gather.go
+++ b/audit/gather/gather.go
@@ -143,7 +143,6 @@ func NewCaptureConfiguration() *Configuration {
 			{"goroutine", 1}, // includes aggregated goroutines with tags
 			{"goroutine", 2}, // includes full per-goroutine stacks
 			{"heap", 0},
-			{"allocs", 0},
 			{"mutex", 0},
 			{"threadcreate", 0},
 			{"block", 0},


### PR DESCRIPTION
https://pkg.go.dev/runtime/pprof#hdr-Heap_profile-Profile
https://pkg.go.dev/runtime/pprof#hdr-Allocs_profile-Profile
>  Allocs profile [¶](https://pkg.go.dev/runtime/pprof#hdr-Allocs_profile-Profile)
The allocs profile is the same as the heap profile but changes the default pprof display to -alloc_space, the total number of bytes allocated since the program began (including garbage-collected bytes).

based on this, it doesn't make sense to collect allocs in addition to the heap profile, right? It is just a flag:
`go tool pprof -top -sample_index=alloc_objects s1.prof | head -n 20`
and
`go tool pprof -top -sample_index=inuse_objects s1.prof  | head -n 20`
give the same data.
One can choose between `alloc_objects`, `alloc_bytes`, `inuse_objects` and `inuse_space` from the heap profile file