### PR TITLE
Add ability to pass seed to context

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -68,6 +68,7 @@ type settings struct {
 	JSEventPrefix       string   `json:"jetstream_event_prefix"`
 	InboxPrefix         string   `json:"inbox_prefix"`
 	UserJwt             string   `json:"user_jwt"`
+	UserSeed            string   `json:"user_seed"`
 	ColorScheme         string   `json:"color_scheme"`
 	TLSFirst            bool     `json:"tls_first"`
 	WinCertStoreType    string   `json:"windows_cert_store"`
@@ -379,7 +380,10 @@ func (c *Context) NATSOptions(opts ...nats.Option) ([]nats.Option, error) {
 
 		nopts = append(nopts, nko)
 
-	case c.UserJWT() != "":
+	case c.UserJWT() != "" && c.UserSeed() != "":
+		nopts = append(nopts, nats.UserJWTAndSeed(c.UserJWT(), c.UserSeed()))
+
+	case c.UserJWT() != "" && c.UserSeed() == "":
 		userCB := func() (string, error) {
 			return c.UserJWT(), nil
 		}
@@ -963,9 +967,23 @@ func WithUserJWT(p string) Option {
 	}
 }
 
+// WithUserSeed sets the user seed
+func WithUserSeed(p string) Option {
+	return func(s *settings) {
+		if p != "" {
+			s.UserSeed = p
+		}
+	}
+}
+
 // UserJWT retrieves the configured user jwt, empty if not set
 func (c *Context) UserJWT() string {
 	return c.config.UserJwt
+}
+
+// UserSeed retrieves the configured user seed, empty if not set
+func (c *Context) UserSeed() string {
+	return c.config.UserSeed
 }
 
 // WithSocksProxy sets the SOCKS5 Proxy.

--- a/natscontext/testdata/nats/context/user_pass_token_creds.json
+++ b/natscontext/testdata/nats/context/user_pass_token_creds.json
@@ -16,6 +16,7 @@
   "jetstream_event_prefix": "",
   "inbox_prefix": "",
   "user_jwt": "",
+  "user_seed": "",
   "color_scheme": "",
   "tls_first": false,
   "windows_cert_store": "",


### PR DESCRIPTION
This will give the nats-cli and others the ability to separately pass the JWT and seed to connect.

Plan is to add the seed as a cli/env option for the nats cli and then can call `natscontext.WithUserSeed(opts.UserSeed)` when building the connection options.