### PR TITLE
Fix bugs and add tests in audit/jetstream_checks.go

### DIFF
--- a/audit/jetstream_checks.go
+++ b/audit/jetstream_checks.go
@@ -21,6 +21,12 @@ import (
 	"github.com/nats-io/jsm.go/monitor"
 )
 
+// streamWithConsumers extends StreamInfo with consumer detail as gathered by the audit tool.
+type streamWithConsumers struct {
+	api.StreamInfo
+	ConsumerDetail []api.ConsumerInfo `json:"consumer_detail"`
+}
+
 func RegisterJetStreamChecks(collection *CheckCollection) error {
 	return collection.Register(
 		Check{
@@ -109,7 +115,6 @@ func checkStreamLaggingReplicas(check *Check, r *archive.Reader, examples *Examp
 
 	accountsWithStreams := make(map[string]any)
 	streamsInspected := make(map[string]any)
-	laggingReplicas := 0
 
 	for _, accountName := range accountNames {
 		accountTag := archive.TagAccount(accountName)
@@ -171,7 +176,6 @@ func checkStreamLaggingReplicas(check *Check, r *archive.Reader, examples *Examp
 					lastSeq := streamDetail.State.LastSeq
 					if lastSeq < threshold {
 						examples.Add("%s/%s server %s lastSequence: %d is behind highest lastSequence: %d on server: %s", accountName, streamName, serverName, lastSeq, highestLastSeq, highestLastSeqServer)
-						laggingReplicas += 1
 					}
 				}
 			}
@@ -180,8 +184,8 @@ func checkStreamLaggingReplicas(check *Check, r *archive.Reader, examples *Examp
 
 	log.Infof("Inspected %d streams across %d accounts", len(streamsInspected), len(accountsWithStreams))
 
-	if laggingReplicas > 0 {
-		log.Errorf("Found %d replicas lagging >%.0f%% behind", laggingReplicas, lastSequenceLagThreshold)
+	if examples.Count() > 0 {
+		log.Errorf("Found %d replicas lagging >%.0f%% behind", examples.Count(), lastSequenceLagThreshold)
 		return Fail, nil
 	}
 
@@ -218,7 +222,7 @@ func checkStreamHighCardinality(check *Check, r *archive.Reader, examples *Examp
 	}
 
 	if examples.Count() > 0 {
-		log.Errorf("Found %d streams with subjects cardinality exceeding %f", examples.Count(), numSubjectsThreshold)
+		log.Errorf("Found %d streams with subjects cardinality exceeding %.0f", examples.Count(), numSubjectsThreshold)
 		return PassWithIssues, nil
 	}
 
@@ -370,11 +374,6 @@ func checkStreamMetadataMonitoring(_ *Check, r *archive.Reader, examples *Exampl
 func checkConsumerMetadataMonitoring(_ *Check, r *archive.Reader, examples *ExamplesCollection, log api.Logger) (Outcome, error) {
 	streamDetailsTag := archive.TagStreamInfo()
 	var foundCrit bool
-
-	type streamWithConsumers struct {
-		api.StreamInfo
-		ConsumerDetail []api.ConsumerInfo `json:"consumer_detail"`
-	}
 
 	for _, accountName := range r.AccountNames() {
 		accountTag := archive.TagAccount(accountName)

--- a/audit/jetstream_checks_test.go
+++ b/audit/jetstream_checks_test.go
@@ -8,11 +8,6 @@ import (
 	"github.com/nats-io/jsm.go/audit/archive"
 )
 
-type streamWithConsumers struct {
-	api.StreamInfo
-	ConsumerDetail []api.ConsumerInfo `json:"consumer_detail"`
-}
-
 func setupJetstreamCheck(t *testing.T, checkid string, streams map[string]any) Outcome {
 	tmp := t.TempDir()
 	archivePath := filepath.Join(tmp, "audit.zip")
@@ -90,6 +85,25 @@ func TestJETSTREAM_001(t *testing.T) {
 			t.Errorf("expected result %v, got %v", Pass, result)
 		}
 	})
+
+	t.Run("Should pass for an empty stream where all replicas have no messages", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_001", map[string]any{
+			"N1": &api.StreamInfo{Config: api.StreamConfig{Name: "S1"}, State: api.StreamState{LastSeq: 0}, Cluster: &api.ClusterInfo{Leader: "N1"}},
+			"N2": &api.StreamInfo{Config: api.StreamConfig{Name: "S1"}, State: api.StreamState{LastSeq: 0}, Cluster: &api.ClusterInfo{Leader: "N1"}},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	t.Run("Should pass for a single-replica stream", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_001", map[string]any{
+			"N1": &api.StreamInfo{Config: api.StreamConfig{Name: "S1"}, State: api.StreamState{LastSeq: 500}, Cluster: &api.ClusterInfo{Leader: "N1"}},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
 }
 
 func TestJETSTREAM_002(t *testing.T) {
@@ -105,6 +119,16 @@ func TestJETSTREAM_002(t *testing.T) {
 	t.Run("Should pass when subject count is normal", func(t *testing.T) {
 		result := setupJetstreamCheck(t, "JETSTREAM_002", map[string]any{
 			"N1": &api.StreamInfo{Config: api.StreamConfig{Name: "S1"}, State: api.StreamState{NumSubjects: 50_000}, Cluster: &api.ClusterInfo{Leader: "N1"}},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	// check uses >, so exactly at the threshold must pass
+	t.Run("Should pass when subject count is exactly at the threshold", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_002", map[string]any{
+			"N1": &api.StreamInfo{Config: api.StreamConfig{Name: "S1"}, State: api.StreamState{NumSubjects: 1_000_000}, Cluster: &api.ClusterInfo{Leader: "N1"}},
 		})
 		if result != Pass {
 			t.Errorf("expected result %v, got %v", Pass, result)
@@ -164,6 +188,34 @@ func TestJETSTREAM_003(t *testing.T) {
 			t.Errorf("expected result %v, got %v", Pass, result)
 		}
 	})
+
+	t.Run("Should pass when no limits are configured", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_003", map[string]any{
+			"N1": &api.StreamInfo{
+				Config:  api.StreamConfig{Name: "S1"}, // MaxMsgs=0, MaxBytes=0, MaxConsumers=0
+				State:   api.StreamState{Msgs: 99999, Bytes: 99999, Consumers: 999},
+				Cluster: &api.ClusterInfo{Leader: "N1"},
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	// checkLimit uses >, so exactly at 90% of the limit must pass:
+	// MaxMsgs=1000, threshold=int64(1000*0.9)=900; Msgs=900 → 900>900 is false → Pass
+	t.Run("Should pass when message usage is exactly at the threshold boundary", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_003", map[string]any{
+			"N1": &api.StreamInfo{
+				Config:  api.StreamConfig{Name: "S1", MaxMsgs: 1000},
+				State:   api.StreamState{Msgs: 900},
+				Cluster: &api.ClusterInfo{Leader: "N1"},
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
 }
 
 func TestJETSTREAM_004(t *testing.T) {
@@ -186,7 +238,8 @@ func TestJETSTREAM_004(t *testing.T) {
 		}
 	})
 
-	t.Run("Should pass when metadata check is enabled but healthy", func(t *testing.T) {
+	// msgs-warn fires when Msgs <= threshold; Msgs=600 is above 500 so no warnings are raised
+	t.Run("Should pass when monitoring is enabled and stream is healthy", func(t *testing.T) {
 		result := setupJetstreamCheck(t, "JETSTREAM_004", map[string]any{
 			"N1": &api.StreamInfo{
 				Config: api.StreamConfig{
@@ -196,12 +249,75 @@ func TestJETSTREAM_004(t *testing.T) {
 						"io.nats.monitor.msgs-warn": "500",
 					},
 				},
+				State:   api.StreamState{Msgs: 600},
+				Cluster: &api.ClusterInfo{Leader: "N1"},
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	// msgs-critical fires when Msgs <= threshold
+	t.Run("Should fail when metadata check reports a critical", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_004", map[string]any{
+			"N1": &api.StreamInfo{
+				Config: api.StreamConfig{
+					Name: "S1",
+					Metadata: map[string]string{
+						"io.nats.monitor.enabled":       "true",
+						"io.nats.monitor.msgs-critical": "500",
+					},
+				},
 				State:   api.StreamState{Msgs: 100},
 				Cluster: &api.ClusterInfo{Leader: "N1"},
 			},
 		})
-		if result != PassWithIssues {
-			t.Errorf("expected result %v, got %v", PassWithIssues, result)
+		if result != Fail {
+			t.Errorf("expected result %v, got %v", Fail, result)
+		}
+	})
+
+	t.Run("Should pass when monitoring metadata is not enabled", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_004", map[string]any{
+			"N1": &api.StreamInfo{
+				Config:  api.StreamConfig{Name: "S1"},
+				State:   api.StreamState{Msgs: 10},
+				Cluster: &api.ClusterInfo{Leader: "N1"},
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	t.Run("Should skip non-leader server artifacts", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_004", map[string]any{
+			"N1": &api.StreamInfo{ // leader, healthy
+				Config: api.StreamConfig{
+					Name: "S1",
+					Metadata: map[string]string{
+						"io.nats.monitor.enabled":       "true",
+						"io.nats.monitor.msgs-critical": "500",
+					},
+				},
+				State:   api.StreamState{Msgs: 600},
+				Cluster: &api.ClusterInfo{Leader: "N1"},
+			},
+			"N2": &api.StreamInfo{ // not the leader; unhealthy data must be ignored
+				Config: api.StreamConfig{
+					Name: "S1",
+					Metadata: map[string]string{
+						"io.nats.monitor.enabled":       "true",
+						"io.nats.monitor.msgs-critical": "500",
+					},
+				},
+				State:   api.StreamState{Msgs: 10},
+				Cluster: &api.ClusterInfo{Leader: "N1"}, // N2 is not the leader
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
 		}
 	})
 }
@@ -262,4 +378,78 @@ func TestJETSTREAM_005(t *testing.T) {
 			t.Errorf("expected result %v, got %v", Pass, result)
 		}
 	})
+
+	t.Run("Should pass when consumer monitoring is not enabled", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_005", map[string]any{
+			"N1": &streamWithConsumers{
+				StreamInfo: api.StreamInfo{
+					Config:  api.StreamConfig{Name: "ORDERS"},
+					Cluster: &api.ClusterInfo{Leader: "N1"},
+				},
+				ConsumerDetail: []api.ConsumerInfo{
+					{
+						Name:          "NO_MONITORING",
+						Stream:        "ORDERS",
+						Cluster:       &api.ClusterInfo{Leader: "N1"},
+						Config:        api.ConsumerConfig{}, // no monitoring metadata
+						NumAckPending: 100,
+					},
+				},
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	t.Run("Should skip consumer checks for non-leader server artifacts", func(t *testing.T) {
+		result := setupJetstreamCheck(t, "JETSTREAM_005", map[string]any{
+			"N1": &streamWithConsumers{ // leader, healthy consumer
+				StreamInfo: api.StreamInfo{
+					Config:  api.StreamConfig{Name: "ORDERS"},
+					Cluster: &api.ClusterInfo{Leader: "N1"},
+				},
+				ConsumerDetail: []api.ConsumerInfo{
+					{
+						Name:    "LEADER_CONSUMER",
+						Stream:  "ORDERS",
+						Cluster: &api.ClusterInfo{Leader: "N1"},
+						Config: api.ConsumerConfig{
+							Metadata: map[string]string{
+								"io.nats.monitor.enabled":                  "true",
+								"io.nats.monitor.outstanding-ack-critical": "20",
+							},
+						},
+						NumAckPending: 5,
+					},
+				},
+			},
+			"N2": &streamWithConsumers{ // not the leader; unhealthy consumer data must be ignored
+				StreamInfo: api.StreamInfo{
+					Config:  api.StreamConfig{Name: "ORDERS"},
+					Cluster: &api.ClusterInfo{Leader: "N1"},
+				},
+				ConsumerDetail: []api.ConsumerInfo{
+					{
+						Name:    "NON_LEADER_CONSUMER",
+						Stream:  "ORDERS",
+						Cluster: &api.ClusterInfo{Leader: "N1"}, // N2 is not the leader
+						Config: api.ConsumerConfig{
+							Metadata: map[string]string{
+								"io.nats.monitor.enabled":                  "true",
+								"io.nats.monitor.outstanding-ack-critical": "20",
+							},
+						},
+						NumAckPending: 100, // unhealthy, but skipped because not leader
+					},
+				},
+			},
+		})
+		if result != Pass {
+			t.Errorf("expected result %v, got %v", Pass, result)
+		}
+	})
+
+	// Consumer monitoring only defines critical thresholds (no warning thresholds),
+	// so the PassWithIssues branch in checkConsumerMetadataMonitoring is unreachable via metadata.
 }


### PR DESCRIPTION
checkStreamLaggingReplicas maintained a redundant laggingReplicas counter that was always identical to examples.Count(); both were incremented together on every lag detection. Remove the counter and use examples.Count() directly for the log message and the return decision.

checkStreamHighCardinality logged the subjects threshold with %f, producing output like "exceeding 1000000.000000". Change to %.0f.

streamWithConsumers was defined as a function-local type inside checkConsumerMetadataMonitoring and identically redefined as a package-level type in the test file. Promote it to package level in the production file and remove the duplicate from the test.

TestJETSTREAM_004 "Should pass when metadata check is enabled but healthy" used Msgs=100 with msgs-warn=500; since the check fires when Msgs <= threshold this was a second warn scenario, not a pass. The Pass outcome was untested. Change to Msgs=600, which is above the warn watermark, and fix the test name and assertion accordingly.

Add missing subtests:

JETSTREAM_001: empty stream (all replicas at LastSeq=0 sets streamIsEmpty=true and skips lag analysis) and single-replica stream (no peers to compare against) both return Pass.

JETSTREAM_002: exactly 1,000,000 subjects must pass since the check uses >, not >=.

JETSTREAM_003: streams with no limits configured (limit<=0 causes checkLimit to return early) pass, and a stream at exactly 90% of its limit passes because checkLimit uses >.

JETSTREAM_004: critical-level metadata failure returns Fail; absent monitoring metadata returns Pass; non-leader server artifacts are skipped so an unhealthy non-leader does not affect the result.

JETSTREAM_005: absent consumer monitoring metadata returns Pass; non-leader consumer artifacts are skipped. Add a comment noting that the PassWithIssues branch is unreachable because consumer monitoring only defines critical thresholds, not warning thresholds.