### PR TITLE
fix: websocket connections with path in url

### DIFF
--- a/natscontext/context.go
+++ b/natscontext/context.go
@@ -99,6 +99,7 @@ type Context struct {
 	config    *settings
 	path      string
 	resolvers map[string]CredentialResolver
+	proxyPath string
 }
 
 // String returns a redacted summary of the context so %s, %v, and %+v
@@ -192,7 +193,9 @@ func (s *settings) GoString() string {
 func New(name string, load bool, opts ...Option) (*Context, error) {
 	if !load {
 		c := &Context{Name: name, config: &settings{}}
-		c.configureNewContext(opts...)
+		if err := c.configureNewContext(opts...); err != nil {
+			return nil, err
+		}
 		return c, nil
 	}
 
@@ -229,7 +232,9 @@ func NewFromBytes(data []byte, opts ...Option) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.configureNewContext(opts...)
+	if err := c.configureNewContext(opts...); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 
@@ -293,12 +298,22 @@ func (c *Context) expand() error {
 	return nil
 }
 
-func (c *Context) configureNewContext(opts ...Option) {
+func (c *Context) configureNewContext(opts ...Option) error {
 	c.applyOpts(opts...)
 
 	if c.config.NSCLookup == "" && c.config.URL == "" && c.config.nscUrl == "" {
 		c.config.URL = nats.DefaultURL
 	}
+
+	cleaned, pp, err := ExtractWSProxyPath(c.ServerURL())
+	if err != nil {
+		return err
+	}
+	c.proxyPath = pp
+	if pp != "" {
+		c.config.URL = cleaned
+	}
+	return nil
 }
 
 // applyOpts runs the supplied options against c.config without the
@@ -493,6 +508,10 @@ func (c *Context) NATSOptions(opts ...nats.Option) ([]nats.Option, error) {
 
 	if c.TLSHandshakeFirst() {
 		nopts = append(nopts, nats.TLSHandshakeFirst())
+	}
+
+	if c.proxyPath != "" {
+		nopts = append(nopts, nats.ProxyPath(c.proxyPath))
 	}
 
 	csOpts, err := c.certStoreNatsOptions()
@@ -846,6 +865,50 @@ func (c *Context) ServerURL() string {
 	default:
 		return nats.DefaultURL
 	}
+}
+
+// ExtractWSProxyPath extracts a WebSocket proxy path from servers.
+func ExtractWSProxyPath(servers string) (cleaned string, proxyPath string, err error) {
+	var pp string
+	var updated []string
+	var hasDefaultPathWS bool
+
+	for s := range strings.SplitSeq(servers, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		u, uerr := url.Parse(s)
+		if uerr != nil {
+			updated = append(updated, s)
+			continue
+		}
+		isWS := u.Scheme == "ws" || u.Scheme == "wss"
+		if isWS && u.Path != "" && u.Path != "/" {
+			reqURI := u.RequestURI()
+			if pp == "" {
+				pp = reqURI
+			} else if pp != reqURI {
+				return "", "", fmt.Errorf("websocket servers with different paths are not supported: %q, %q", pp, reqURI)
+			}
+			u.Path = ""
+			u.RawPath = ""
+			u.RawQuery = ""
+			u.ForceQuery = false
+			updated = append(updated, u.String())
+		} else {
+			if isWS {
+				hasDefaultPathWS = true
+			}
+			updated = append(updated, s)
+		}
+	}
+
+	if pp != "" && hasDefaultPathWS {
+		return "", "", fmt.Errorf("mixing websocket servers with and without a proxy path is not supported")
+	}
+
+	return strings.Join(updated, ","), pp, nil
 }
 
 // WithUser sets the username

--- a/natscontext/context_test.go
+++ b/natscontext/context_test.go
@@ -426,3 +426,61 @@ func TestExpandEnvInPaths(t *testing.T) {
 		t.Error("cert: ~ was not expanded")
 	}
 }
+
+func TestExtractWSProxyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		servers   string
+		proxyPath string
+	}{
+		{"nats url unchanged", "nats://localhost:4222", "nats://localhost:4222", ""},
+		{"ws without path", "ws://localhost:8080", "ws://localhost:8080", ""},
+		{"wss without path", "wss://localhost:8080", "wss://localhost:8080", ""},
+		{"ws with path", "ws://localhost:8080/nats", "ws://localhost:8080", "/nats"},
+		{"wss with path", "wss://host:443/proxy/nats", "wss://host:443", "/proxy/nats"},
+		{"ws root path only", "ws://localhost:8080/", "ws://localhost:8080/", ""},
+		{"multiple ws same path", "ws://h1:80/path,ws://h2:80/path", "ws://h1:80,ws://h2:80", "/path"},
+		{"mixed ws and nats", "ws://h1:80/path,nats://h2:4222", "ws://h1:80,nats://h2:4222", "/path"},
+		{"ws with path and query", "ws://proxy.example/nats?tenant=a", "ws://proxy.example", "/nats?tenant=a"},
+		{"wss with path and query", "wss://proxy.example/nats?tenant=a&token=b", "wss://proxy.example", "/nats?tenant=a&token=b"},
+		{"empty string", "", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			servers, proxyPath, err := natscontext.ExtractWSProxyPath(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if servers != tc.servers {
+				t.Errorf("servers: got %q, want %q", servers, tc.servers)
+			}
+			if proxyPath != tc.proxyPath {
+				t.Errorf("proxyPath: got %q, want %q", proxyPath, tc.proxyPath)
+			}
+		})
+	}
+
+	t.Run("different paths error", func(t *testing.T) {
+		_, _, err := natscontext.ExtractWSProxyPath("ws://h1:80/path-a,ws://h2:80/path-b")
+		if err == nil {
+			t.Fatal("expected error for differing proxy paths")
+		}
+		want := `websocket servers with different paths are not supported: "/path-a", "/path-b"`
+		if err.Error() != want {
+			t.Errorf("error: got %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("mixed default and proxy path error", func(t *testing.T) {
+		_, _, err := natscontext.ExtractWSProxyPath("ws://a.example/nats,ws://b.example")
+		if err == nil {
+			t.Fatal("expected error for mixed default and proxy paths")
+		}
+		want := "mixing websocket servers with and without a proxy path is not supported"
+		if err.Error() != want {
+			t.Errorf("error: got %q, want %q", err.Error(), want)
+		}
+	})
+}

--- a/natscontext/registry.go
+++ b/natscontext/registry.go
@@ -132,7 +132,9 @@ func (r *Registry) Load(ctx context.Context, name string, opts ...Option) (*Cont
 			}
 		}
 		if name == "" {
-			c.configureNewContext(opts...)
+			if err := c.configureNewContext(opts...); err != nil {
+				return nil, err
+			}
 			return c, nil
 		}
 	}
@@ -165,7 +167,9 @@ func (r *Registry) Load(ctx context.Context, name string, opts ...Option) (*Cont
 	if r.noExpand {
 		c.applyOpts(opts...)
 	} else {
-		c.configureNewContext(opts...)
+		if err := c.configureNewContext(opts...); err != nil {
+			return nil, err
+		}
 	}
 
 	return c, nil


### PR DESCRIPTION
Fix WebSocket connections when the URL has a path. The path was getting dropped.

See https://github.com/nats-io/natscli/pull/1672#discussion_r3313123178