### PR TITLE
[FIXED] Message Tracing: Would not report all servers in some cases

### DIFF
--- a/api/server/tracing/tracing.go
+++ b/api/server/tracing/tracing.go
@@ -105,7 +105,6 @@ func GetMsgTrace(sub *nats.Subscription, traceSubject string, timeout time.Durat
 		origin  *server.MsgTraceEvent
 		traces  = map[string]*server.MsgTraceEvent{}
 		missing = map[string]*server.MsgTraceEvent{}
-		servers = map[string]*server.MsgTraceEvent{}
 	)
 
 	var retErr error
@@ -170,10 +169,8 @@ func GetMsgTrace(sub *nats.Subscription, traceSubject string, timeout time.Durat
 			// Add to servers map.
 			traces[hop] = e
 		}
-		// Add the trace of this server in the map
-		servers[e.Server.Name] = e
 		// Check if we got all the expected traces...
-		if gotAllServers(servers, origin != nil) {
+		if origin != nil && gotAllServers(traces, origin) {
 			break
 		}
 	}
@@ -199,36 +196,20 @@ func GetMsgTrace(sub *nats.Subscription, traceSubject string, timeout time.Durat
 	return origin, retErr
 }
 
-func gotAllServers(all map[string]*server.MsgTraceEvent, hasOrigin bool) bool {
-	if !hasOrigin {
-		return false
+func gotAllServers(hops map[string]*server.MsgTraceEvent, root *server.MsgTraceEvent) bool {
+	if root.Hops == 0 {
+		return true
 	}
-	for _, tr := range all {
-		// We already made sure that we have an ingress, so no need to check
-		// for `nil` here.
-		in := tr.Ingress()
-		// If this is the ingress from the CLIENT, skip this check
-		if in.Kind != server.CLIENT {
-			// Do we have the ingress server in the `all` map? If not, then
-			// clearly we don't have them all.
-			if _, ok := all[in.Name]; !ok {
-				return false
-			}
+	for _, eg := range root.Egresses() {
+		if eg.Hop == "" {
+			continue
 		}
-		// If this trace has "hops" count, then check the egress to see if
-		// we have the trace for those servers.
-		if tr.Hops > 0 {
-			egresses := tr.Egresses()
-			for _, eg := range egresses {
-				if eg.Kind == server.CLIENT {
-					continue
-				}
-				// If we still don't have this egress server, then we don't
-				// have them all.
-				if _, ok := all[eg.Name]; !ok {
-					return false
-				}
-			}
+		nr, ok := hops[eg.Hop]
+		if !ok {
+			return false
+		}
+		if !gotAllServers(hops, nr) {
+			return false
 		}
 	}
 	return true

--- a/api/server/tracing/tracing_test.go
+++ b/api/server/tracing/tracing_test.go
@@ -469,3 +469,138 @@ func TestMsgTracingGotThemAll(t *testing.T) {
 		}
 	}
 }
+
+func TestMsgTracingDuplicateServerNameWithSvcImport(t *testing.T) {
+	s, nc, sub := setupTest(t)
+	defer s.Shutdown()
+	defer nc.Close()
+
+	nc.Publish("trace.id", []byte(`{"server":{"name":"A","host":"0.0.0.0","id":"ID1","cluster":"local"},"request":{"header":{"Nats-Trace-Dest":["trace.id"]},"msgsize":121},"hops":2,"events":[{"type":"in","kind":0,"cid":23,"name":"cli","acc":"C","subj":"c.1"},{"type":"si","acc":"B","from":"c.1","to":"b.1"},{"type":"si","acc":"A","from":"b.1","to":"a.1"},{"type":"eg","kind":1,"cid":9,"name":"B","hop":"1"},{"type":"eg","kind":1,"cid":9,"name":"B","hop":"2"}]}`))
+	nc.Publish("trace.id", []byte(`{"server":{"name":"B","host":"0.0.0.0","id":"ID2","cluster":"local"},"request":{"header":{"Nats-Request-Info":["{\"acc\":\"C\",\"svc\":\"B\",\"rtt\":551583}"],"Nats-Trace-Dest":["_R_.7lA8cE.nnNF0Q"],"Nats-Trace-Hop":["1"]},"msgsize":174},"hops":2,"events":[{"type":"in","kind":1,"cid":9,"name":"A","acc":"A","subj":"a.1"},{"type":"eg","kind":4,"cid":12,"name":"C","hop":"1.1"},{"type":"eg","kind":4,"cid":14,"name":"D","hop":"1.2"}]}`))
+	nc.Publish("trace.id", []byte(`{"server":{"name":"B","host":"0.0.0.0","id":"ID2","cluster":"local"},"request":{"header":{"Nats-Request-Info":["{\"acc\":\"C\",\"rtt\":551583}"],"Nats-Trace-Dest":["_R_.WJGHEP.2s5D6s"],"Nats-Trace-Hop":["2"]},"msgsize":164},"events":[{"type":"in","kind":1,"cid":9,"name":"A","acc":"B","subj":"b.1"},{"type":"eg","kind":0,"cid":16,"name":"cli","sub":"b.\u003e"}]}`))
+	nc.Publish("trace.id", []byte(`{"server":{"name":"C","host":"0.0.0.0","id":"ID3","cluster":"C"},"request":{"header":{"Nats-Request-Info":["{\"acc\":\"C\",\"svc\":\"B\",\"rtt\":551583}"],"Nats-Trace-Dest":["_R_.7lA8cE.nnNF0Q"],"Nats-Trace-Hop":["1.1"]},"msgsize":176},"events":[{"type":"in","kind":4,"cid":7,"name":"B","acc":"A","subj":"a.1"},{"type":"eg","kind":0,"cid":9,"name":"cli","sub":"a.\u003e"}]}`))
+	nc.Publish("trace.id", []byte(`{"server":{"name":"D","host":"0.0.0.0","id":"ID4","cluster":"D"},"request":{"header":{"Nats-Request-Info":["{\"acc\":\"C\",\"svc\":\"B\",\"rtt\":551583}"],"Nats-Trace-Dest":["_R_.7lA8cE.nnNF0Q"],"Nats-Trace-Hop":["1.2"]},"msgsize":176},"events":[{"type":"in","kind":4,"cid":7,"name":"B","acc":"A","subj":"a.1"},{"type":"eg","kind":0,"cid":9,"name":"cli","sub":"a.\u003e"}]}`))
+
+	e, err := GetMsgTrace(sub, "trace.id", 500*time.Millisecond, nil)
+	if err != nil {
+		t.Fatalf("Error getting trace: %v", err)
+	}
+	if sn := e.Server.Name; sn != "A" {
+		t.Fatalf("Expected server %q, got %q", "A", sn)
+	}
+	sis := e.ServiceImports()
+	if n := len(sis); n != 2 {
+		t.Fatalf("Expected 2 service imports, got %v", n)
+	}
+	for i, si := range sis {
+		switch i {
+		case 0:
+			if si.Account != "B" {
+				t.Fatalf("Expected account %q got %q", "B", si.Account)
+			}
+			if si.From != "c.1" {
+				t.Fatalf("Expected %q to be %q, got %q", "from", "c.1", si.From)
+			}
+			if si.To != "b.1" {
+				t.Fatalf("Expected %q to be %q, got %q", "to", "b.1", si.To)
+			}
+		case 1:
+			if si.Account != "A" {
+				t.Fatalf("Expected account %q got %q", "A", si.Account)
+			}
+			if si.From != "b.1" {
+				t.Fatalf("Expected %q to be %q, got %q", "from", "b.1", si.From)
+			}
+			if si.To != "a.1" {
+				t.Fatalf("Expected %q to be %q, got %q", "to", "a.1", si.To)
+			}
+		}
+	}
+	egresses := e.Egresses()
+	if n := len(egresses); n != 2 {
+		t.Fatalf("Expected 2 egresses, got %v", n)
+	}
+	for i, eg := range egresses {
+		if eg.Kind != srv.ROUTER {
+			t.Fatalf("Expected egress to a ROUTER, got %+v", eg)
+		}
+		if eg.Link == nil {
+			t.Fatal("Link is nil!")
+		}
+		if sn := eg.Link.Server.Name; sn != "B" {
+			t.Fatalf("Expected link to %q, got %q", "B", sn)
+		}
+		switch i {
+		case 0:
+			if eg.Hop != "1" {
+				t.Fatalf("Expected Hop to be %q, got %q", "1", eg.Hop)
+			}
+			egs := eg.Link.Egresses()
+			if n := len(egs); n != 2 {
+				t.Fatalf("Expected 2 egresses from B, got %v", n)
+			}
+			for j, e := range egs {
+				if e.Kind != srv.LEAF {
+					t.Fatalf("Expected egress to a LEAF, got %+v", e)
+				}
+				if e.Link == nil {
+					t.Fatal("Link is nil!")
+				}
+				switch j {
+				case 0:
+					if sn := e.Link.Server.Name; sn != "C" {
+						t.Fatalf("Expected link to %q, got %q", "C", sn)
+					}
+					if e.Hop != "1.1" {
+						t.Fatalf("Expected Hop to be %q, got %q", "1.1", e.Hop)
+					}
+					if e.Link == nil {
+						t.Fatal("Link is nil!")
+					}
+					if sn := e.Link.Server.Name; sn != "C" {
+						t.Fatalf("Expected link to %q, got %q", "C", sn)
+					}
+				case 1:
+					if sn := e.Link.Server.Name; sn != "D" {
+						t.Fatalf("Expected link to %q, got %q", "D", sn)
+					}
+					if e.Hop != "1.2" {
+						t.Fatalf("Expected Hop to be %q, got %q", "1.2", e.Hop)
+					}
+					if e.Link == nil {
+						t.Fatal("Link is nil!")
+					}
+					if sn := e.Link.Server.Name; sn != "D" {
+						t.Fatalf("Expected link to %q, got %q", "C", sn)
+					}
+				}
+				finalegs := e.Link.Egresses()
+				if n := len(finalegs); n != 1 {
+					t.Fatalf("Expected 1 egress, got %v", n)
+				}
+				eg := finalegs[0]
+				if eg.Kind != srv.CLIENT {
+					t.Fatalf("Expected egress to a CLIENT, got %+v", eg)
+				}
+				if eg.Subscription != "a.>" {
+					t.Fatalf("Expected subscription on %q, got %q", "a.>", eg.Subscription)
+				}
+			}
+		case 1:
+			if eg.Hop != "2" {
+				t.Fatalf("Expected Hop to be %q, got %q", "2", eg.Hop)
+			}
+			egs := eg.Link.Egresses()
+			if n := len(egs); n != 1 {
+				t.Fatalf("Expected 1 egresses from B, got %v", n)
+			}
+			eg := egs[0]
+			if eg.Kind != srv.CLIENT {
+				t.Fatalf("Expected egress to a CLIENT, got %+v", eg)
+			}
+			if eg.Subscription != "b.>" {
+				t.Fatalf("Expected subscription on %q, got %q", "b.>", eg.Subscription)
+			}
+		}
+	}
+}


### PR DESCRIPTION
With service import, in some situations the library would not report all servers involved in the graph because it could be that there are multiple events for the same server name.

This PR addresses the issue and adds a test that demonstrates the fix.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>