### PR TITLE
Dereference schemas with Go

### DIFF
--- a/api/gen_dereference.go
+++ b/api/gen_dereference.go
@@ -1,0 +1,531 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build ignore
+
+// Dereferences the source JSON schemas resolving all definitions and producing
+// flat JSON schema files that are easy to load remotely and validate as they are
+// standalone single files.
+//
+// Numbers are carried through as literals so that values like the maximum of a
+// Go uint64 survive the round trip unchanged.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	sourceDir       = "schema_source"
+	targetDir       = "schemas"
+	definitionsFile = "definitions.json"
+	indent          = "  "
+)
+
+// object is a JSON object that remembers the order its keys were added in,
+// encoding/json can not be used for this since it sorts map keys on output
+type object struct {
+	keys []string
+	vals map[string]any
+}
+
+func newObject() *object {
+	return &object{vals: make(map[string]any)}
+}
+
+func (o *object) set(k string, v any) {
+	_, known := o.vals[k]
+	if !known {
+		o.keys = append(o.keys, k)
+	}
+	o.vals[k] = v
+}
+
+func (o *object) get(k string) (any, bool) {
+	v, ok := o.vals[k]
+	return v, ok
+}
+
+func (o *object) has(k string) bool {
+	_, ok := o.vals[k]
+	return ok
+}
+
+// loader reads and caches the parsed source schemas keyed on their path
+// relative to sourceDir
+type loader struct {
+	docs map[string]any
+}
+
+func newLoader() *loader {
+	return &loader{docs: make(map[string]any)}
+}
+
+func (l *loader) load(file string) (any, error) {
+	doc, known := l.docs[file]
+	if known {
+		return doc, nil
+	}
+
+	body, err := os.ReadFile(filepath.Join(sourceDir, filepath.FromSlash(file)))
+	if err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+
+	doc, err = decode(dec)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse %s: %w", file, err)
+	}
+
+	l.docs[file] = doc
+
+	return doc, nil
+}
+
+func decode(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeValue(dec, tok)
+}
+
+func decodeValue(dec *json.Decoder, tok json.Token) (any, error) {
+	delim, isDelim := tok.(json.Delim)
+	if !isDelim {
+		return tok, nil
+	}
+
+	switch delim {
+	case '{':
+		obj := newObject()
+
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return nil, err
+			}
+
+			key, isString := keyTok.(string)
+			if !isString {
+				return nil, fmt.Errorf("expected an object key, got %v", keyTok)
+			}
+
+			val, err := decode(dec)
+			if err != nil {
+				return nil, err
+			}
+
+			obj.set(key, val)
+		}
+
+		_, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		return obj, nil
+
+	case '[':
+		arr := []any{}
+
+		for dec.More() {
+			val, err := decode(dec)
+			if err != nil {
+				return nil, err
+			}
+
+			arr = append(arr, val)
+		}
+
+		_, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		return arr, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected delimiter %v", delim)
+	}
+}
+
+// reference is a resolved $ref pointing at a location in a specific source file
+type reference struct {
+	file    string
+	pointer []string
+}
+
+func (r reference) String() string {
+	return r.file + "#/" + strings.Join(r.pointer, "/")
+}
+
+// parseRef resolves ref relative to the file it appears in
+func parseRef(base string, ref string) (reference, error) {
+	file, fragment, _ := strings.Cut(ref, "#")
+
+	if file == "" {
+		file = base
+	} else {
+		file = path.Join(path.Dir(base), file)
+	}
+
+	var pointer []string
+	for part := range strings.SplitSeq(fragment, "/") {
+		if part == "" {
+			continue
+		}
+
+		part = strings.ReplaceAll(part, "~1", "/")
+		part = strings.ReplaceAll(part, "~0", "~")
+		pointer = append(pointer, part)
+	}
+
+	if len(pointer) == 0 {
+		return reference{}, fmt.Errorf("%q in %s does not reference a definition", ref, base)
+	}
+
+	return reference{file: file, pointer: pointer}, nil
+}
+
+func (l *loader) resolve(ref reference) (any, error) {
+	node, err := l.load(ref.file)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, part := range ref.pointer {
+		obj, isObject := node.(*object)
+		if !isObject {
+			return nil, fmt.Errorf("%s does not resolve, %q is not in an object", ref, part)
+		}
+
+		val, known := obj.get(part)
+		if !known {
+			return nil, fmt.Errorf("%s does not resolve, %q is unknown", ref, part)
+		}
+
+		node = val
+	}
+
+	return node, nil
+}
+
+// dereference replaces every $ref below node with the contents of what it
+// references. Keys alongside a $ref are kept in their original order and win
+// over the same key in the referenced definition, keys only present in the
+// definition are appended.
+//
+// base is the file node was read from, stack holds the references being
+// resolved so that a definition cycle is reported rather than recursed into.
+func (l *loader) dereference(node any, base string, stack []reference) (any, error) {
+	switch val := node.(type) {
+	case []any:
+		res := make([]any, len(val))
+
+		for i, item := range val {
+			item, err := l.dereference(item, base, stack)
+			if err != nil {
+				return nil, err
+			}
+
+			res[i] = item
+		}
+
+		return res, nil
+
+	case *object:
+		res := newObject()
+
+		for _, key := range val.keys {
+			if key == "$ref" {
+				continue
+			}
+
+			item, err := l.dereference(val.vals[key], base, stack)
+			if err != nil {
+				return nil, err
+			}
+
+			res.set(key, item)
+		}
+
+		rawRef, known := val.get("$ref")
+		if !known {
+			return res, nil
+		}
+
+		refStr, isString := rawRef.(string)
+		if !isString {
+			return nil, fmt.Errorf("$ref in %s is not a string", base)
+		}
+
+		ref, err := parseRef(base, refStr)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, seen := range stack {
+			if seen.String() == ref.String() {
+				return nil, fmt.Errorf("definition cycle resolving %s", ref)
+			}
+		}
+
+		target, err := l.resolve(ref)
+		if err != nil {
+			return nil, err
+		}
+
+		target, err = l.dereference(target, ref.file, append(stack, ref))
+		if err != nil {
+			return nil, err
+		}
+
+		targetObj, isObject := target.(*object)
+		if !isObject {
+			return nil, fmt.Errorf("%s does not reference an object", ref)
+		}
+
+		for _, key := range targetObj.keys {
+			if res.has(key) {
+				continue
+			}
+
+			res.set(key, targetObj.vals[key])
+		}
+
+		return res, nil
+
+	default:
+		return node, nil
+	}
+}
+
+// encode writes v in the same layout jq produces, two space indents with no
+// escaping of HTML characters and numbers written exactly as they were read
+func encode(buf *bytes.Buffer, v any, depth int) error {
+	switch val := v.(type) {
+	case *object:
+		if len(val.keys) == 0 {
+			buf.WriteString("{}")
+			return nil
+		}
+
+		buf.WriteString("{\n")
+
+		for i, key := range val.keys {
+			if i > 0 {
+				buf.WriteString(",\n")
+			}
+
+			writeIndent(buf, depth+1)
+			writeString(buf, key)
+			buf.WriteString(": ")
+
+			err := encode(buf, val.vals[key], depth+1)
+			if err != nil {
+				return err
+			}
+		}
+
+		buf.WriteString("\n")
+		writeIndent(buf, depth)
+		buf.WriteString("}")
+
+		return nil
+
+	case []any:
+		if len(val) == 0 {
+			buf.WriteString("[]")
+			return nil
+		}
+
+		buf.WriteString("[\n")
+
+		for i, item := range val {
+			if i > 0 {
+				buf.WriteString(",\n")
+			}
+
+			writeIndent(buf, depth+1)
+
+			err := encode(buf, item, depth+1)
+			if err != nil {
+				return err
+			}
+		}
+
+		buf.WriteString("\n")
+		writeIndent(buf, depth)
+		buf.WriteString("]")
+
+		return nil
+
+	case string:
+		writeString(buf, val)
+		return nil
+
+	case json.Number:
+		buf.WriteString(val.String())
+		return nil
+
+	case bool:
+		if val {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return nil
+
+	case nil:
+		buf.WriteString("null")
+		return nil
+
+	default:
+		return fmt.Errorf("cannot encode %T", v)
+	}
+}
+
+func writeIndent(buf *bytes.Buffer, depth int) {
+	for range depth {
+		buf.WriteString(indent)
+	}
+}
+
+func writeString(buf *bytes.Buffer, s string) {
+	buf.WriteByte('"')
+
+	for _, r := range s {
+		switch r {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\f':
+			buf.WriteString(`\f`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(buf, `\u%04x`, r)
+				continue
+			}
+
+			buf.WriteRune(r)
+		}
+	}
+
+	buf.WriteByte('"')
+}
+
+func compile(l *loader, file string) error {
+	doc, err := l.load(file)
+	if err != nil {
+		return err
+	}
+
+	res, err := l.dereference(doc, file, nil)
+	if err != nil {
+		return err
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	err = encode(buf, res, 0)
+	if err != nil {
+		return err
+	}
+
+	buf.WriteString("\n")
+
+	target := filepath.Join(targetDir, filepath.FromSlash(file))
+
+	err = os.MkdirAll(filepath.Dir(target), 0755)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(target, buf.Bytes(), 0644)
+}
+
+func sources() ([]string, error) {
+	var files []string
+
+	err := filepath.WalkDir(sourceDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(p) != ".json" {
+			return nil
+		}
+		if d.Name() == definitionsFile {
+			return nil
+		}
+
+		rel, err := filepath.Rel(sourceDir, p)
+		if err != nil {
+			return err
+		}
+
+		files = append(files, filepath.ToSlash(rel))
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+func main() {
+	log.SetFlags(0)
+
+	files, err := sources()
+	if err != nil {
+		log.Fatalf("could not list %s: %v", sourceDir, err)
+	}
+
+	l := newLoader()
+
+	for _, file := range files {
+		err = compile(l, file)
+		if err != nil {
+			log.Fatalf("could not compile %s: %v", file, err)
+		}
+	}
+
+	log.Printf("Dereferenced %d schemas from %s into %s", len(files), sourceDir, targetDir)
+}

--- a/api/schemas_generated.go
+++ b/api/schemas_generated.go
@@ -1,4 +1,4 @@
-// auto generated 2026-04-30 13:11:26.122705 +0200 CEST m=+0.011602376
+// auto generated 2026-07-22 12:41:48.258815 +0300 EEST m=+0.011302084
 
 package api
 

--- a/compile_schemas.sh
+++ b/compile_schemas.sh
@@ -1,51 +1,13 @@
 #!/bin/bash
 
-# uses https://www.npmjs.com/package/json-dereference-cli to dereference the source JSON schemas
-# resolving all definitions and producing flat json schema files that's easy to load remotely and
-# validate as they are standalone single files.
+# dereferences the source JSON schemas resolving all definitions and producing flat
+# json schema files that's easy to load remotely and validate as they are standalone
+# single files.
 #
-# required json-dereference and jq in your path
+# this is also run as part of 'go generate'
 
 set -e
 
-assert_directory_must_exist() {
-    if [ ! -d $1 ]
-    then
-      echo "ERROR: ${1} does not exist, use fully qualified paths"
-      exit 1
-    fi
-}
+cd "$(dirname "$0")"
 
-dereference_directory () {
-  local pwd=$(pwd)
-  local source_dir="${pwd}/$1"
-  local target_dir="${pwd}/$2"
-
-  assert_directory_must_exist "${source_dir}"
-  cd "${source_dir}"
-
-  assert_directory_must_exist "${target_dir}"
-
-  local source_list=$(find .)
-
-  for file in $source_list;do
-    if [ -d $file ];then
-      mkdir -p "${target_dir}/${file}"
-    fi
-
-    if [ $(basename "${file}") == "definitions.json" ];then
-      continue
-    fi
-
-    if [[ "${file: -5}" == ".json" ]];then
-      json-dereference -s "${file}" -o "${target_dir}/${file}.temp.json"
-
-      # seds here is because go uint64 is too big for node and some overflows/confusion happen, so we put it back how it should be :(
-      jq < "${target_dir}/${file}.temp.json" |sed -e s/9223372036854776000/9223372036854775807/ | sed -e s/18446744073709552000/18446744073709551615/ > "${target_dir}/${file}"
-      rm -f "${target_dir}/${file}.temp.json"
-    fi
-  done
-}
-
-dereference_directory "schema_source" "schemas"
-
+go run api/gen_dereference.go

--- a/jsm.go
+++ b/jsm.go
@@ -14,6 +14,7 @@
 // Package jsm provides client helpers for managing and interacting with NATS JetStream
 package jsm
 
+//go:generate go run api/gen_dereference.go
 //go:generate go run api/gen.go
 
 import (

--- a/schemas/jetstream/api/v1/consumer_configuration.json
+++ b/schemas/jetstream/api/v1/consumer_configuration.json
@@ -169,7 +169,7 @@
       "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
       "type": "integer",
       "maximum": 9223372036854775807,
-      "minimum": -9223372036854775807
+      "minimum": -9223372036854775808
     },
     "filter_subject": {
       "description": "Filter the stream by a single subjects",
@@ -209,7 +209,7 @@
       "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
       "type": "integer",
       "maximum": 9223372036854775807,
-      "minimum": -9223372036854775807
+      "minimum": -9223372036854775808
     },
     "idle_heartbeat": {
       "minimum": 0,

--- a/schemas/jetstream/api/v1/consumer_create_request.json
+++ b/schemas/jetstream/api/v1/consumer_create_request.json
@@ -181,7 +181,7 @@
           "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "filter_subject": {
           "description": "Filter the stream by a single subjects",
@@ -221,7 +221,7 @@
           "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "idle_heartbeat": {
           "minimum": 0,

--- a/schemas/jetstream/api/v1/consumer_create_response.json
+++ b/schemas/jetstream/api/v1/consumer_create_response.json
@@ -202,7 +202,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             },
             "filter_subject": {
               "description": "Filter the stream by a single subjects",
@@ -242,7 +242,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             },
             "idle_heartbeat": {
               "minimum": 0,

--- a/schemas/jetstream/api/v1/consumer_info_response.json
+++ b/schemas/jetstream/api/v1/consumer_info_response.json
@@ -202,7 +202,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             },
             "filter_subject": {
               "description": "Filter the stream by a single subjects",
@@ -242,7 +242,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             },
             "idle_heartbeat": {
               "minimum": 0,

--- a/schemas/jetstream/api/v1/consumer_list_response.json
+++ b/schemas/jetstream/api/v1/consumer_list_response.json
@@ -267,7 +267,7 @@
                     "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                     "type": "integer",
                     "maximum": 9223372036854775807,
-                    "minimum": -9223372036854775807
+                    "minimum": -9223372036854775808
                   },
                   "filter_subject": {
                     "description": "Filter the stream by a single subjects",
@@ -307,7 +307,7 @@
                     "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                     "type": "integer",
                     "maximum": 9223372036854775807,
-                    "minimum": -9223372036854775807
+                    "minimum": -9223372036854775808
                   },
                   "idle_heartbeat": {
                     "minimum": 0,

--- a/schemas/jetstream/api/v1/consumer_reset_response.json
+++ b/schemas/jetstream/api/v1/consumer_reset_response.json
@@ -236,7 +236,7 @@
                   "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                   "type": "integer",
                   "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775807
+                  "minimum": -9223372036854775808
                 },
                 "filter_subject": {
                   "description": "Filter the stream by a single subjects",
@@ -276,7 +276,7 @@
                   "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                   "type": "integer",
                   "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775807
+                  "minimum": -9223372036854775808
                 },
                 "idle_heartbeat": {
                   "minimum": 0,

--- a/schemas/jetstream/api/v1/stream_configuration.json
+++ b/schemas/jetstream/api/v1/stream_configuration.json
@@ -475,7 +475,7 @@
           "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         }
       }
     },

--- a/schemas/jetstream/api/v1/stream_create_request.json
+++ b/schemas/jetstream/api/v1/stream_create_request.json
@@ -478,7 +478,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             }
           }
         },

--- a/schemas/jetstream/api/v1/stream_create_response.json
+++ b/schemas/jetstream/api/v1/stream_create_response.json
@@ -493,7 +493,7 @@
                       "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                       "type": "integer",
                       "maximum": 9223372036854775807,
-                      "minimum": -9223372036854775807
+                      "minimum": -9223372036854775808
                     }
                   }
                 },

--- a/schemas/jetstream/api/v1/stream_info_response.json
+++ b/schemas/jetstream/api/v1/stream_info_response.json
@@ -493,7 +493,7 @@
                       "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                       "type": "integer",
                       "maximum": 9223372036854775807,
-                      "minimum": -9223372036854775807
+                      "minimum": -9223372036854775808
                     }
                   }
                 },

--- a/schemas/jetstream/api/v1/stream_list_response.json
+++ b/schemas/jetstream/api/v1/stream_list_response.json
@@ -558,7 +558,7 @@
                             "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                             "type": "integer",
                             "maximum": 9223372036854775807,
-                            "minimum": -9223372036854775807
+                            "minimum": -9223372036854775808
                           }
                         }
                       },

--- a/schemas/jetstream/api/v1/stream_restore_request.json
+++ b/schemas/jetstream/api/v1/stream_restore_request.json
@@ -482,7 +482,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             }
           }
         },

--- a/schemas/jetstream/api/v1/stream_snapshot_response.json
+++ b/schemas/jetstream/api/v1/stream_snapshot_response.json
@@ -517,7 +517,7 @@
                   "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                   "type": "integer",
                   "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775807
+                  "minimum": -9223372036854775808
                 }
               }
             },

--- a/schemas/jetstream/api/v1/stream_update_request.json
+++ b/schemas/jetstream/api/v1/stream_update_request.json
@@ -478,7 +478,7 @@
               "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             }
           }
         },

--- a/schemas/jetstream/api/v1/stream_update_response.json
+++ b/schemas/jetstream/api/v1/stream_update_response.json
@@ -493,7 +493,7 @@
                       "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
                       "type": "integer",
                       "maximum": 9223372036854775807,
-                      "minimum": -9223372036854775807
+                      "minimum": -9223372036854775808
                     }
                   }
                 },

--- a/schemas/micro/v1/stats_response.json
+++ b/schemas/micro/v1/stats_response.json
@@ -86,14 +86,14 @@
             "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
             "type": "integer",
             "maximum": 9223372036854775807,
-            "minimum": -9223372036854775807
+            "minimum": -9223372036854775808
           },
           "num_errors": {
             "description": "The number of errors this endpoint encountered",
             "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
             "type": "integer",
             "maximum": 9223372036854775807,
-            "minimum": -9223372036854775807
+            "minimum": -9223372036854775808
           },
           "last_error": {
             "description": "The last error the service encountered",
@@ -104,14 +104,14 @@
             "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
             "type": "integer",
             "maximum": 9223372036854775807,
-            "minimum": -9223372036854775807
+            "minimum": -9223372036854775808
           },
           "average_processing_time": {
             "description": "The average time spent processing requests",
             "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
             "type": "integer",
             "maximum": 9223372036854775807,
-            "minimum": -9223372036854775807
+            "minimum": -9223372036854775808
           },
           "queue_group": {
             "description": "The queue group this endpoint listens on for requests",

--- a/schemas/server/monitor/v1/varz.json
+++ b/schemas/server/monitor/v1/varz.json
@@ -76,7 +76,7 @@
       "$comment": "signed 64 bit integer",
       "type": "integer",
       "maximum": 9223372036854775807,
-      "minimum": -9223372036854775807
+      "minimum": -9223372036854775808
     },
     "max_subscriptions": {
       "type": "integer",
@@ -170,7 +170,7 @@
           "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "write_timeout": {
           "description": "The policy to apply to sockets being closed due to write_deadline",
@@ -263,7 +263,7 @@
           "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "write_timeout": {
           "description": "The policy to apply to sockets being closed due to write_deadline",
@@ -365,7 +365,7 @@
           "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "write_timeout": {
           "description": "The policy to apply to sockets being closed due to write_deadline",
@@ -425,7 +425,7 @@
           "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
           "type": "integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "max_ack_pending": {
           "type": "integer",
@@ -470,7 +470,7 @@
           "description": "How long the connection has to complete the websocket setup",
           "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
           "maximum": 9223372036854775807,
-          "minimum": -9223372036854775807
+          "minimum": -9223372036854775808
         },
         "auth_timeout": {
           "type": "number",
@@ -541,7 +541,7 @@
               "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             },
             "sync_always": {
               "type": "boolean",
@@ -666,7 +666,7 @@
                     "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
                     "type": "integer",
                     "maximum": 9223372036854775807,
-                    "minimum": -9223372036854775807
+                    "minimum": -9223372036854775808
                   },
                   "lag": {
                     "type": "integer",
@@ -705,14 +705,14 @@
                   "description": "The count of pending entries in the meta layer",
                   "$comment": "signed 64 bit integer",
                   "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775807
+                  "minimum": -9223372036854775808
                 },
                 "pending_size": {
                   "type": "integer",
                   "description": "The size of pending entries in the meta layer in bytes",
                   "$comment": "signed 64 bit integer",
                   "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775807
+                  "minimum": -9223372036854775808
                 },
                 "last_time": {
                   "type": "string",
@@ -724,7 +724,7 @@
                   "description": "The duration of the last snapshot in nanoseconds",
                   "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
                   "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775807
+                  "minimum": -9223372036854775808
                 }
               }
             }
@@ -751,7 +751,7 @@
               "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             },
             "max_batch_inflight_per_stream": {
               "type": "integer",
@@ -770,7 +770,7 @@
               "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
               "type": "integer",
               "maximum": 9223372036854775807,
-              "minimum": -9223372036854775807
+              "minimum": -9223372036854775808
             }
           }
         }
@@ -785,7 +785,7 @@
       "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
       "type": "integer",
       "maximum": 9223372036854775807,
-      "minimum": -9223372036854775807
+      "minimum": -9223372036854775808
     },
     "write_timeout": {
       "description": "The policy to apply to sockets being closed due to write_deadline",


### PR DESCRIPTION
This adds a Claude written dereference tool that fixes a number of issues the javascript ones had related to large numbers in schemas etc

It's also just faster and easier