### PR TITLE
Treat an exhausted page as end-of-data in hasNextPage

### DIFF
--- a/audit/gather/gather.go
+++ b/audit/gather/gather.go
@@ -625,8 +625,9 @@ func (g *gather) hasNextPage(endpoint string, decoded map[string]any, pageLimit 
 		return false, nil
 	}
 
+	segments := strings.Split(jsonPath, ".")
 	currentNode := any(decoded)
-	for _, segment := range strings.Split(jsonPath, ".") {
+	for i, segment := range segments {
 		objectNode, isObject := currentNode.(map[string]any)
 		if !isObject {
 			return false, fmt.Errorf("expected object at path segment %q in %s, but got %T", segment, endpoint, currentNode)
@@ -634,9 +635,22 @@ func (g *gather) hasNextPage(endpoint string, decoded map[string]any, pageLimit 
 
 		nextNode, exists := objectNode[segment]
 		if !exists {
+			// A server omits an empty collection entirely (`omitempty`), and an exhausted page
+			// is exactly that. Absent at the final segment is end-of-data, not a malformed
+			// response. Intermediate segments are still a genuine schema mismatch.
+			if i == len(segments)-1 {
+				g.log.Debugf("paging check for %s: %q absent, treating as end of data", endpoint, segment)
+				return false, nil
+			}
 			return false, fmt.Errorf("missing key %q in path for endpoint %s", segment, endpoint)
 		}
 		currentNode = nextNode
+	}
+
+	// An explicit JSON null carries the same end-of-data meaning as an omitted key.
+	if currentNode == nil {
+		g.log.Debugf("paging check for %s: null at end of path, treating as end of data", endpoint)
+		return false, nil
 	}
 
 	arrayNode, isArray := currentNode.([]any)

--- a/audit/gather/gather_paging_test.go
+++ b/audit/gather/gather_paging_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gather
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+// hasNextPage decides whether to request another page from the array length of the current one.
+// A server omits an empty collection entirely (`omitempty`), so the page landing exactly on
+// `total` carries no key at all. That is end-of-data, not a malformed response, and a full page
+// is what makes it reachable: any endpoint holding an exact multiple of pageLimit gets there.
+func TestHasNextPage(t *testing.T) {
+	g := &gather{log: newLogger(&bytes.Buffer{}, api.InfoLevel)}
+
+	const pageLimit = 1024
+
+	// page marshals a body whose list holds n objects, matching the shape of a real response.
+	page := func(key string, n int) string {
+		items := make([]any, n)
+		for i := range items {
+			items[i] = map[string]any{}
+		}
+		b, err := json.Marshal(map[string]any{"data": map[string]any{key: items}})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return string(b)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		endpoint string
+		body     string
+		wantMore bool
+		wantErr  bool
+	}{
+		// The regression. Verbatim shape of a real SUBSZ page at offset == total: the paging
+		// fields are present and the list key is gone.
+		{
+			"subsz exhausted page omits the list", "SUBSZ",
+			`{"data":{"num_subscriptions":65,"total":1024,"offset":1024,"limit":1024}}`, false, false,
+		},
+		// Same shape on JSZ, whose account_details is likewise omitempty.
+		{
+			"jsz exhausted page omits the list", "JSZ",
+			`{"data":{"streams":0,"total":1024,"offset":1024,"limit":1024}}`, false, false,
+		},
+		// A field without omitempty holding a nil slice marshals to null. Same zero-items signal.
+		{"null list", "SUBSZ", `{"data":{"subscriptions_list":null}}`, false, false},
+		// A field without omitempty holding an empty slice. This is what CONNZ does today.
+		{"empty list", "CONNZ", `{"data":{"connections":[]}}`, false, false},
+		{"short page ends paging", "SUBSZ", page("subscriptions_list", pageLimit-1), false, false},
+		{"full page continues paging", "SUBSZ", page("subscriptions_list", pageLimit), true, false},
+
+		// Errors that must survive the fix, so a mis-specified endpointPagingInfo path is still
+		// reported rather than silently truncating collection to a single page.
+		{"missing intermediate segment", "SUBSZ", `{"nope":{}}`, false, true},
+		{"non-object mid-path", "SUBSZ", `{"data":"scalar"}`, false, true},
+		{"non-array at end of path", "SUBSZ", `{"data":{"subscriptions_list":"scalar"}}`, false, true},
+
+		// Endpoints absent from endpointPagingInfo are not paged at all.
+		{"unpaged endpoint", "VARZ", `{"data":{}}`, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(tc.body), &decoded); err != nil {
+				t.Fatalf("bad fixture: %v", err)
+			}
+
+			more, err := g.hasNextPage(tc.endpoint, decoded, pageLimit)
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("expected an error, got none (more=%v)", more)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if more != tc.wantMore {
+				t.Fatalf("hasNextPage = %v, want %v", more, tc.wantMore)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #828.

`hasNextPage` decides whether to fetch another page from the length of the current one, so a page
that returns exactly `pageLimit` items is read as "there is more" and the next offset lands on
`total`. The server answers that with an empty page, and because the list fields are tagged
`omitempty` the key is not in the response at all. `hasNextPage` treated the absent key as a fatal
error, which aborts the whole capture, so SUBSZ and JSZ cannot be gathered when either holds an
exact multiple of 1024 items.

An absent key at the final path segment now reports end-of-data. An intermediate segment still
errors, so a wrong `endpointPagingInfo` path is still reported rather than silently truncating
collection to one page; the error cases in the test cover that.

## Verification

Against a live server, holding subscriptions so SUBSZ reports exactly 1024, capturing server
endpoints, profiles and account endpoints, same server and same subscriptions before and after:

| | archive | profiles | account files | metadata |
|---|---|---|---|---|
| before | 21,842 B | 0 | 0 | 0 |
| after | 58,755 B | 8 | 19 | 1 |

Paging itself is unchanged. The patched build collects exactly `total` subscriptions at 1023 (1
page), 1024 (2), 1025 (2), 2048 (3) and 2049 (3).

The new test fails on unpatched code for the two omitted-key cases and the null case, and passes
after. Both omitted-key cases are also confirmed end to end: `Gather` aborts on SUBSZ at 1024
subscriptions and on JSZ at 1024 `account_details`, and clears the boundary once patched. The five
CI gates all pass locally on the patched tree: `go fmt`, `misspell`, `staticcheck`, `go vet` and
`go test -race`.

## Two things to decide

**The `null` branch may be more than you want.** A field without `omitempty` holding a nil slice
marshals to `null`, which is the same zero-items signal as an omitted key and fails the same way at
`currentNode.([]any)`. None of the three endpoints in `endpointPagingInfo` does that today, so the
branch is defensive rather than exercised in production; CONNZ, the only one without `omitempty`,
emits `[]`. Say the word and I will drop it.

**An empty trailing page is now archived.** At an exact multiple of `pageLimit` the run stores a
final page artifact with zero items, because the store happens before the paging check. That is a
consequence of deciding paging from array length and it predates this change; the error simply hid
it before. Paging from the response's own `offset` and `total` would remove both the empty artifact
and the boundary condition, but it touches every endpoint's response handling, so I have kept it out
of this change.
