### PR TITLE
(#1676) Add backup package for editing stream backups on disk

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package backup reads, verifies, inspects and edits JetStream stream backups
+// on disk without a server connection.
+//
+// Only the NATS Server 2.15 backup format is supported: an s2 compressed
+// NATSARC1 archive named stream.tar.s2 next to a backup.json meta file, the
+// layout written by jsm.Stream.SnapshotToDirectory and read by
+// jsm.Manager.RestoreSnapshotFromDirectory. Older tar based backups are
+// refused.
+package backup
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+const (
+	// DataFile is the archive file name inside a backup directory
+	DataFile = "stream.tar.s2"
+	// MetaFile is the meta file name inside a backup directory
+	MetaFile = "backup.json"
+
+	stateEntry     = "state.json"
+	consumerPrefix = "consumers/"
+)
+
+// ErrNotV2Backup is returned when a source is not a NATS Server 2.15 stream backup
+var ErrNotV2Backup = errors.New("not a NATS Server 2.15 stream backup")
+
+// Item is one decoded archive entry: *State, *Consumer, *Message or End
+type Item interface {
+	item()
+}
+
+// State is the state.json entry that leads every backup
+type State struct {
+	Ts    int64
+	State api.StreamState
+}
+
+// Consumer is one consumers/<name> entry holding the JSON encoded config and state
+type Consumer struct {
+	Name string
+	Ts   int64
+	Data []byte
+}
+
+// Message is one stored message; Body yields the headers followed by the payload
+// and is only valid until the next call to Decoder.Next
+type Message struct {
+	Subject     string
+	Seq         uint64
+	Ts          int64
+	HdrSize     int64
+	PayloadSize int64
+	Body        io.Reader
+}
+
+// End is the end-of-backup sentinel
+type End struct{}
+
+func (*State) item()    {}
+func (*Consumer) item() {}
+func (*Message) item()  {}
+func (End) item()       {}
+
+// EntryRef identifies an archive entry by position and identity
+type EntryRef struct {
+	Ordinal int
+	Kind    string
+	Name    string
+	Seq     uint64
+}
+
+func (r EntryRef) String() string {
+	switch r.Kind {
+	case "message":
+		return "entry #" + strconv.Itoa(r.Ordinal) + " message " + r.Name + " seq " + strconv.FormatUint(r.Seq, 10)
+	case "":
+		return "no entries"
+	default:
+		return "entry #" + strconv.Itoa(r.Ordinal) + " " + r.Kind + " " + r.Name
+	}
+}
+
+// storedMsgSize mirrors the server's unexported fileStoreMsgSizeRaw
+func storedMsgSize(slen int, hlen, mlen int64) uint64 {
+	if hlen == 0 {
+		return uint64(22 + int64(slen) + mlen + 8)
+	}
+	return uint64(22 + int64(slen) + 4 + hlen + mlen + 8)
+}
+
+func backupPaths(dir string) (data string, meta string, err error) {
+	data = filepath.Join(dir, DataFile)
+	meta = filepath.Join(dir, MetaFile)
+	for _, p := range []string{data, meta} {
+		if _, err := os.Stat(p); err != nil {
+			return "", "", err
+		}
+	}
+	return data, meta, nil
+}

--- a/backup/codec_test.go
+++ b/backup/codec_test.go
@@ -1,0 +1,547 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats-server/v2/server/archive"
+
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/jsm.go/api"
+)
+
+type testMsg struct {
+	subject string
+	seq     uint64
+	ts      int64
+	hdr     string
+	body    string
+}
+
+func (m testMsg) item() *Message {
+	return &Message{
+		Subject:     m.subject,
+		Seq:         m.seq,
+		Ts:          m.ts,
+		HdrSize:     int64(len(m.hdr)),
+		PayloadSize: int64(len(m.body)),
+		Body:        strings.NewReader(m.hdr + m.body),
+	}
+}
+
+func consumerJSON(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := json.Marshal(server.SnapshotConsumerState{
+		ConsumerConfig: &server.ConsumerConfig{Durable: name, Name: name, FilterSubject: "orders.>"},
+		ConsumerState:  &server.ConsumerState{Delivered: server.SequencePair{Consumer: 1, Stream: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func encodeBackup(t *testing.T, st api.StreamState, consumers map[string][]byte, msgs []testMsg, sentinel bool) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+	if err := enc.WriteState(1000, st); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range slices.Sorted(maps.Keys(consumers)) {
+		if err := enc.WriteConsumer(name, 2000, consumers[name]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, m := range msgs {
+		if err := enc.WriteMessage(m.item()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if sentinel {
+		if err := enc.WriteEnd(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func framed(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	w := s2.NewWriter(&b)
+	if _, err := w.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}
+
+func rawArchive(t *testing.T, fn func(w *archive.Writer)) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	s2w := s2.NewWriter(&buf)
+	aw := archive.NewWriter(s2w)
+	fn(aw)
+	if err := s2w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func rawEntry(t *testing.T, w *archive.Writer, name string, ts int64, seq uint64, hdrSize, payloadSize int64, data []byte) {
+	t.Helper()
+	err := w.WriteHeader(&archive.Header{Name: name, Timestamp: ts, Sequence: seq, HeaderSize: hdrSize, PayloadSize: payloadSize})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(data); err != nil && !errors.Is(err, archive.ErrWriteTooLong) {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stateJSON(t *testing.T, st api.StreamState) []byte {
+	t.Helper()
+	data, err := json.Marshal(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func decodeAll(t *testing.T, data []byte) ([]Item, error) {
+	t.Helper()
+	dec := NewDecoder(bytes.NewReader(data))
+	var items []Item
+	for {
+		item, err := dec.Next()
+		if err != nil {
+			return items, err
+		}
+		if m, ok := item.(*Message); ok {
+			body, err := io.ReadAll(m.Body)
+			if err != nil {
+				return items, err
+			}
+			m.Body = bytes.NewReader(body)
+		}
+		items = append(items, item)
+		if _, ok := item.(End); ok {
+			return items, nil
+		}
+	}
+}
+
+func TestCodecRoundTrip(t *testing.T) {
+	st := api.StreamState{Msgs: 3, Bytes: 999, FirstSeq: 2, LastSeq: 9, Consumers: 2}
+	consumers := map[string][]byte{"c1": consumerJSON(t, "c1"), "c2": consumerJSON(t, "c2")}
+	msgs := []testMsg{
+		{"orders.new", 2, 10, "", "first"},
+		{"orders.paid", 5, 20, "NATS/1.0\r\nKV-Operation: DEL\r\n\r\n", ""},
+		{"orders.shipped", 9, 30, "NATS/1.0\r\nX-A: 1\r\n\r\n", strings.Repeat("z", 100000)},
+	}
+
+	data := encodeBackup(t, st, consumers, msgs, true)
+	items, err := decodeAll(t, data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(items) != 1+2+3+1 {
+		t.Fatalf("expected 7 items, got %d", len(items))
+	}
+
+	s := items[0].(*State)
+	if s.Ts != 1000 || !reflect.DeepEqual(s.State, st) {
+		t.Fatalf("state mismatch: %+v", s)
+	}
+	for i, name := range []string{"c1", "c2"} {
+		c := items[1+i].(*Consumer)
+		if c.Name != name || c.Ts != 2000 || !bytes.Equal(c.Data, consumers[name]) {
+			t.Fatalf("consumer %d mismatch: %+v", i, c)
+		}
+	}
+	for i, want := range msgs {
+		got := items[3+i].(*Message)
+		body, _ := io.ReadAll(got.Body)
+		if got.Subject != want.subject || got.Seq != want.seq || got.Ts != want.ts || got.HdrSize != int64(len(want.hdr)) || got.PayloadSize != int64(len(want.body)) || string(body) != want.hdr+want.body {
+			t.Fatalf("message %d mismatch: %+v", i, got)
+		}
+	}
+	if _, ok := items[6].(End); !ok {
+		t.Fatalf("expected End, got %T", items[6])
+	}
+
+	dec := NewDecoder(bytes.NewReader(data))
+	for range items {
+		if _, err := dec.Next(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := dec.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF after End, got %v", err)
+	}
+}
+
+func TestEncoderRejectsShortBody(t *testing.T) {
+	enc := NewEncoder(io.Discard)
+	if err := enc.WriteState(0, api.StreamState{}); err != nil {
+		t.Fatal(err)
+	}
+	err := enc.WriteMessage(&Message{Subject: "a", Seq: 1, PayloadSize: 10, Body: strings.NewReader("short")})
+	if err == nil || !strings.Contains(err.Error(), "10 declared") {
+		t.Fatalf("expected short body error, got %v", err)
+	}
+}
+
+func TestDecoderRejectsNonV2(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":    nil,
+		"plain s2": s2.Encode(nil, []byte("not an archive at all")),
+		"tar-ish": func() []byte {
+			var b bytes.Buffer
+			w := s2.NewWriter(&b)
+			w.Write(make([]byte, 1024))
+			w.Close()
+			return b.Bytes()
+		}(),
+		"random": []byte("this is definitely not s2 framed data"),
+		"magic only": func() []byte {
+			var b bytes.Buffer
+			w := s2.NewWriter(&b)
+			w.Write([]byte(archive.MagicBytes))
+			w.Close()
+			return b.Bytes()
+		}(),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := decodeAll(t, data)
+			if !errors.Is(err, ErrNotV2Backup) {
+				t.Fatalf("expected ErrNotV2Backup, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "NATS Server 2.15") {
+				t.Fatalf("error should name the requirement: %v", err)
+			}
+		})
+	}
+
+	_, err := decodeAll(t, framed(t, []byte("not an archive at all")))
+	if !errors.Is(err, archive.ErrInvalidArchive) {
+		t.Fatalf("expected the reader's ErrInvalidArchive underneath, got %v", err)
+	}
+	_, err = decodeAll(t, nil)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected the reader's io.EOF underneath, got %v", err)
+	}
+}
+
+func TestDecoderStateMustBeFirst(t *testing.T) {
+	data := rawArchive(t, func(w *archive.Writer) {
+		rawEntry(t, w, "consumers/c1", 0, 0, 0, 2, []byte("{}"))
+	})
+	_, err := decodeAll(t, data)
+	if err == nil || !strings.Contains(err.Error(), `expected state.json first, found "consumers/c1"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data = rawArchive(t, func(w *archive.Writer) {
+		rawEntry(t, w, "state.json", 0, 0, 0, 3, []byte("{{{"))
+	})
+	_, err = decodeAll(t, data)
+	if err == nil || !strings.Contains(err.Error(), "error in state.json") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecoderConsumerCount(t *testing.T) {
+	st := stateJSON(t, api.StreamState{FirstSeq: 1, LastSeq: 1, Consumers: 2})
+	data := rawArchive(t, func(w *archive.Writer) {
+		rawEntry(t, w, "state.json", 0, 0, 0, int64(len(st)), st)
+		c := consumerJSON(t, "c1")
+		rawEntry(t, w, "consumers/c1", 0, 0, 0, int64(len(c)), c)
+		rawEntry(t, w, "orders.new", 5, 1, 0, 2, []byte("hi"))
+	})
+	_, err := decodeAll(t, data)
+	if err == nil || !strings.Contains(err.Error(), `expected consumer entry (1 of 2 remaining), found "orders.new"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for name, body := range map[string]string{
+		"missing config": `{"state":{}}`,
+		"missing state":  `{"config":{"durable_name":"c1"}}`,
+		"not json":       `nope`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			st := stateJSON(t, api.StreamState{FirstSeq: 1, LastSeq: 1, Consumers: 1})
+			data := rawArchive(t, func(w *archive.Writer) {
+				rawEntry(t, w, "state.json", 0, 0, 0, int64(len(st)), st)
+				rawEntry(t, w, "consumers/c1", 0, 0, 0, int64(len(body)), []byte(body))
+			})
+			_, err := decodeAll(t, data)
+			if err == nil || !strings.Contains(err.Error(), `consumer "c1"`) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDecoderSequenceInvariants(t *testing.T) {
+	withState := func(t *testing.T, st api.StreamState, fn func(w *archive.Writer)) []byte {
+		sj := stateJSON(t, st)
+		return rawArchive(t, func(w *archive.Writer) {
+			rawEntry(t, w, "state.json", 0, 0, 0, int64(len(sj)), sj)
+			fn(w)
+		})
+	}
+
+	t.Run("descending", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 1, LastSeq: 3}, func(w *archive.Writer) {
+			rawEntry(t, w, "a", 1, 3, 0, 1, []byte("x"))
+			rawEntry(t, w, "a", 2, 2, 0, 1, []byte("y"))
+		})
+		_, err := decodeAll(t, data)
+		if err == nil || !strings.Contains(err.Error(), "message sequence 2 out of order after entry #2 message a seq 3") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 1, LastSeq: 3}, func(w *archive.Writer) {
+			rawEntry(t, w, "a", 1, 3, 0, 1, []byte("x"))
+			rawEntry(t, w, "a", 2, 3, 0, 1, []byte("y"))
+		})
+		_, err := decodeAll(t, data)
+		if err == nil || !strings.Contains(err.Error(), "message sequence 3 out of order") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("below first_seq", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 10, LastSeq: 30}, func(w *archive.Writer) {
+			rawEntry(t, w, "a", 1, 9, 0, 1, []byte("x"))
+		})
+		_, err := decodeAll(t, data)
+		if err == nil || !strings.Contains(err.Error(), "message sequence 9 out of order") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("first_seq zero with messages", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 0, LastSeq: 0}, func(w *archive.Writer) {
+			rawEntry(t, w, "a", 1, 1, 0, 1, []byte("x"))
+		})
+		_, err := decodeAll(t, data)
+		if err == nil || !strings.Contains(err.Error(), "message sequence 1 out of order: state.json has first_seq 0") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("seq zero entry that is not the sentinel", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 1, LastSeq: 1}, func(w *archive.Writer) {
+			rawEntry(t, w, "a", 1, 1, 0, 1, []byte("x"))
+			rawEntry(t, w, "consumers/late", 7, 0, 0, 2, []byte("{}"))
+		})
+		_, err := decodeAll(t, data)
+		if err == nil || !strings.Contains(err.Error(), `expected message sequence, found entry "consumers/late" with sequence 0 after entry #2 message a seq 1`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("sentinel name ignored", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 1, LastSeq: 1}, func(w *archive.Writer) {
+			rawEntry(t, w, "a", 1, 1, 0, 1, []byte("x"))
+			rawEntry(t, w, "whatever", 0, 0, 0, 0, nil)
+		})
+		items, err := decodeAll(t, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := items[len(items)-1].(End); !ok {
+			t.Fatalf("expected End, got %T", items[len(items)-1])
+		}
+	})
+
+	t.Run("empty backup", func(t *testing.T) {
+		data := withState(t, api.StreamState{FirstSeq: 6, LastSeq: 5}, func(w *archive.Writer) {
+			rawEntry(t, w, "", 0, 0, 0, 0, nil)
+		})
+		items, err := decodeAll(t, data)
+		if err != nil || len(items) != 2 {
+			t.Fatalf("unexpected: %v %d", err, len(items))
+		}
+	})
+}
+
+func TestDecoderTruncation(t *testing.T) {
+	st := api.StreamState{FirstSeq: 1, LastSeq: 2}
+
+	t.Run("at entry boundary", func(t *testing.T) {
+		data := encodeBackup(t, st, nil, []testMsg{{"a", 1, 1, "", "x"}}, false)
+		_, err := decodeAll(t, data)
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("expected io.EOF underneath, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "before the end-of-backup sentinel after entry #2 message a seq 1: EOF") {
+			t.Fatalf("unexpected message: %v", err)
+		}
+	})
+
+	t.Run("mid entry", func(t *testing.T) {
+		sj := stateJSON(t, st)
+		data := rawArchive(t, func(w *archive.Writer) {
+			rawEntry(t, w, "state.json", 0, 0, 0, int64(len(sj)), sj)
+			rawEntry(t, w, "a", 1, 1, 0, 100, []byte("only ten b"))
+		})
+		_, err := decodeAll(t, data)
+		if !errors.Is(err, archive.ErrInvalidArchive) {
+			t.Fatalf("expected ErrInvalidArchive underneath, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "archive: invalid archive stream") {
+			t.Fatalf("unexpected message: %v", err)
+		}
+	})
+
+	t.Run("compressed stream cut", func(t *testing.T) {
+		data := encodeBackup(t, st, nil, []testMsg{{"a", 1, 1, "", strings.Repeat("x", 50000)}, {"b", 2, 2, "", "y"}}, true)
+		_, err := decodeAll(t, data[:len(data)/2])
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+}
+
+func writeBackupDir(t *testing.T, dir string, cfg api.StreamConfig, st api.StreamState, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, DataFile), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sc, err := (&metaFile{Config: cfg, State: st}).marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, MetaFile), sc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyAndInfo(t *testing.T) {
+	st := api.StreamState{Msgs: 0, Bytes: 0, FirstSeq: 2, LastSeq: 9, Consumers: 1}
+	cfg := api.StreamConfig{Name: "ORDERS", Subjects: []string{"orders.>"}}
+	msgs := []testMsg{
+		{"orders.new", 2, 10, "", "first"},
+		{"orders.paid", 5, 20, "NATS/1.0\r\nKV-Operation: DEL\r\n\r\n", ""},
+		{"orders.shipped", 9, 30, "", "last"},
+	}
+	data := encodeBackup(t, st, map[string][]byte{"c1": consumerJSON(t, "c1")}, msgs, true)
+
+	dir := filepath.Join(t.TempDir(), "b")
+	writeBackupDir(t, dir, cfg, st, data)
+
+	rep, err := Verify(dir)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if !rep.Complete || rep.Entries != 6 || rep.Consumers != 1 || rep.Messages != 3 || rep.FirstSeq != 2 || rep.LastSeq != 9 {
+		t.Fatalf("unexpected report: %+v", rep)
+	}
+	if rep.LastGood.Kind != "end" || rep.LastGood.Ordinal != 6 {
+		t.Fatalf("unexpected last good: %+v", rep.LastGood)
+	}
+
+	info, err := Info(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wantBytes uint64
+	for _, m := range msgs {
+		wantBytes += storedMsgSize(len(m.subject), int64(len(m.hdr)), int64(len(m.body)))
+	}
+	if info.Config.Name != "ORDERS" || info.Messages != 3 || info.Bytes != wantBytes || info.FirstSeq != 2 || info.LastSeq != 9 {
+		t.Fatalf("unexpected info: %+v", info)
+	}
+	if info.FirstTime.UnixNano() != 10 || info.LastTime.UnixNano() != 30 {
+		t.Fatalf("unexpected times: %+v", info)
+	}
+	if !info.DeclaredCountsAdvisory || !reflect.DeepEqual(info.Declared, st) || len(info.Consumers) != 1 || info.Consumers[0] != "c1" {
+		t.Fatalf("unexpected declared: %+v", info)
+	}
+
+	truncated := encodeBackup(t, st, map[string][]byte{"c1": consumerJSON(t, "c1")}, msgs, false)
+	tdir := filepath.Join(t.TempDir(), "t")
+	writeBackupDir(t, tdir, cfg, st, truncated)
+	rep, err = Verify(tdir)
+	if err == nil {
+		t.Fatal("expected verify to fail")
+	}
+	if rep == nil || rep.Complete || rep.Entries != 5 || rep.Messages != 3 {
+		t.Fatalf("unexpected report: %+v", rep)
+	}
+	if !strings.Contains(err.Error(), "last good entry: entry #5 message orders.shipped seq 9") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := Info(tdir); err == nil {
+		t.Fatal("expected info to fail")
+	}
+
+	if err := os.Remove(filepath.Join(dir, MetaFile)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Verify(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected missing meta file error, got %v", err)
+	}
+
+	writeBackupDir(t, dir, api.StreamConfig{Name: "bad.name"}, st, data)
+	if _, err := Verify(dir); err == nil || !strings.Contains(err.Error(), `invalid stream name "bad.name"`) {
+		t.Fatalf("expected an invalid name error, got %v", err)
+	}
+
+	writeBackupDir(t, dir, api.StreamConfig{Name: "MEM", Storage: api.MemoryStorage}, st, data)
+	if _, err := Verify(dir); !errors.Is(err, jsm.ErrMemoryStreamNotSupported) {
+		t.Fatalf("expected a memory storage error, got %v", err)
+	}
+}
+
+func TestVerifyRejectsV1Layout(t *testing.T) {
+	dir := t.TempDir()
+	writeBackupDir(t, dir, api.StreamConfig{Name: "OLD"}, api.StreamState{}, framed(t, make([]byte, 2048)))
+
+	_, err := Verify(dir)
+	if !errors.Is(err, ErrNotV2Backup) {
+		t.Fatalf("expected ErrNotV2Backup, got %v", err)
+	}
+}

--- a/backup/decoder.go
+++ b/backup/decoder.go
@@ -1,0 +1,195 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats-server/v2/server/archive"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+type decodePhase int
+
+const (
+	phaseState decodePhase = iota
+	phaseConsumers
+	phaseMessages
+	phaseDone
+)
+
+// Decoder reads a compressed NATSARC1 stream backup as typed items, enforcing
+// the invariants the server's restore relies on: state.json first, exactly
+// consumer_count consumer entries, strictly ascending message sequences and a
+// terminating sentinel
+type Decoder struct {
+	r             *archive.Reader
+	state         *api.StreamState
+	consumersLeft int
+	phase         decodePhase
+	lastSeq       uint64
+	ordinal       int
+	last          EntryRef
+	err           error
+}
+
+// NewDecoder reads the s2 compressed archive from r
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r: archive.NewReader(s2.NewReader(r))}
+}
+
+// LastGood identifies the last entry that decoded cleanly
+func (d *Decoder) LastGood() EntryRef {
+	return d.last
+}
+
+// Next returns the next item; End is returned exactly once, after which io.EOF is returned
+func (d *Decoder) Next() (Item, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	if d.phase == phaseDone {
+		return nil, io.EOF
+	}
+
+	item, err := d.next()
+	if err != nil {
+		d.err = err
+		return nil, err
+	}
+
+	return item, nil
+}
+
+func (d *Decoder) next() (Item, error) {
+	hdr, err := d.r.Next()
+	if err != nil {
+		if d.phase == phaseState {
+			return nil, fmt.Errorf("%w: %w", ErrNotV2Backup, err)
+		}
+		return nil, fmt.Errorf("backup ends before the end-of-backup sentinel after %s: %w", d.last, err)
+	}
+
+	switch d.phase {
+	case phaseState:
+		return d.decodeState(hdr)
+	case phaseConsumers:
+		return d.decodeConsumer(hdr)
+	default:
+		return d.decodeMessage(hdr)
+	}
+}
+
+func (d *Decoder) decodeState(hdr *archive.Header) (Item, error) {
+	if hdr.Name != stateEntry {
+		return nil, fmt.Errorf("expected %s first, found %q", stateEntry, hdr.Name)
+	}
+
+	data, err := io.ReadAll(d.r)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", stateEntry, err)
+	}
+
+	var st api.StreamState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("error in %s: %w", stateEntry, err)
+	}
+	if st.Consumers < 0 {
+		return nil, fmt.Errorf("error in %s: negative consumer_count %d", stateEntry, st.Consumers)
+	}
+
+	d.state = &st
+	d.consumersLeft = st.Consumers
+	d.lastSeq = st.FirstSeq - 1
+	d.phase = phaseConsumers
+	if d.consumersLeft == 0 {
+		d.phase = phaseMessages
+	}
+	d.advance("state", stateEntry, 0)
+
+	return &State{Ts: hdr.Timestamp, State: st}, nil
+}
+
+func (d *Decoder) decodeConsumer(hdr *archive.Header) (Item, error) {
+	name, found := strings.CutPrefix(hdr.Name, consumerPrefix)
+	if !found {
+		return nil, fmt.Errorf("expected consumer entry (%d of %d remaining), found %q", d.consumersLeft, d.state.Consumers, hdr.Name)
+	}
+
+	data, err := io.ReadAll(d.r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read consumer %q state: %w", name, err)
+	}
+
+	var scs server.SnapshotConsumerState
+	if err := json.Unmarshal(data, &scs); err != nil {
+		return nil, fmt.Errorf("failed to decode consumer %q state: %w", name, err)
+	}
+	if scs.ConsumerConfig == nil {
+		return nil, fmt.Errorf("consumer %q is missing config", name)
+	}
+	if scs.ConsumerState == nil {
+		return nil, fmt.Errorf("consumer %q is missing state", name)
+	}
+
+	d.consumersLeft--
+	if d.consumersLeft == 0 {
+		d.phase = phaseMessages
+	}
+	d.advance("consumer", name, 0)
+
+	return &Consumer{Name: name, Ts: hdr.Timestamp, Data: data}, nil
+}
+
+func (d *Decoder) decodeMessage(hdr *archive.Header) (Item, error) {
+	if hdr.Sequence == 0 {
+		if hdr.Timestamp == 0 && hdr.HeaderSize == 0 && hdr.PayloadSize == 0 {
+			d.phase = phaseDone
+			d.advance("end", "", 0)
+			return End{}, nil
+		}
+		return nil, fmt.Errorf("expected message sequence, found entry %q with sequence 0 after %s", hdr.Name, d.last)
+	}
+
+	if hdr.Sequence <= d.lastSeq {
+		if d.lastSeq == math.MaxUint64 {
+			return nil, fmt.Errorf("message sequence %d out of order: %s has first_seq 0", hdr.Sequence, stateEntry)
+		}
+		return nil, fmt.Errorf("message sequence %d out of order after %s", hdr.Sequence, d.last)
+	}
+
+	d.lastSeq = hdr.Sequence
+	d.advance("message", hdr.Name, hdr.Sequence)
+
+	return &Message{
+		Subject:     hdr.Name,
+		Seq:         hdr.Sequence,
+		Ts:          hdr.Timestamp,
+		HdrSize:     hdr.HeaderSize,
+		PayloadSize: hdr.PayloadSize,
+		Body:        d.r,
+	}, nil
+}
+
+func (d *Decoder) advance(kind, name string, seq uint64) {
+	d.ordinal++
+	d.last = EntryRef{Ordinal: d.ordinal, Kind: kind, Name: name, Seq: seq}
+}

--- a/backup/edit.go
+++ b/backup/edit.go
@@ -1,0 +1,590 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+// Result describes a finished edit: the configuration and state written to
+// the meta file and a Report of what the edit did
+type Result struct {
+	Config api.StreamConfig
+	State  api.StreamState
+	Report Report
+}
+
+// DropCounts records how many messages each filter removed, a message is
+// attributed to the first filter that rejected it, evaluated in the order
+// sequence, time, subject, header, payload, then last-per-subject or kv-compact
+type DropCounts struct {
+	Sequence       uint64
+	Time           uint64
+	Subject        uint64
+	Header         uint64
+	Payload        uint64
+	LastPerSubject uint64
+	KVCompact      uint64
+}
+
+// Total is the number of messages dropped by any filter
+func (d DropCounts) Total() uint64 {
+	return d.Sequence + d.Time + d.Subject + d.Header + d.Payload + d.LastPerSubject + d.KVCompact
+}
+
+func (d *DropCounts) add(kind dropKind) {
+	switch kind {
+	case dropSequence:
+		d.Sequence++
+	case dropTime:
+		d.Time++
+	case dropSubject:
+		d.Subject++
+	case dropHeader:
+		d.Header++
+	case dropPayload:
+		d.Payload++
+	case dropLastPerSubject:
+		d.LastPerSubject++
+	case dropKVCompact:
+		d.KVCompact++
+	}
+}
+
+// Report is what an edit did; it is outside the determinism guarantee since
+// the MaxAge warning uses the edit-time clock
+type Report struct {
+	SourceMessages   uint64
+	Kept             uint64
+	Dropped          DropCounts
+	ConsumersKept    int
+	ConsumersDropped int
+	// TombstonesRemovedByContentFilters counts KV delete, purge and limit
+	// markers that a header or payload filter dropped
+	TombstonesRemovedByContentFilters uint64
+	// SubjectStateKeys and SubjectStateBytes describe the per-subject state a
+	// two-pass edit held: distinct subjects and the accounted size of their
+	// keys and slots, not process memory
+	SubjectStateKeys  uint64
+	SubjectStateBytes uint64
+	// Warnings describe stream limits that will trim the result on restore
+	Warnings []string
+
+	Obfuscation *ObfuscationReport
+}
+
+// ObfuscationReport describes an obfuscated edit
+type ObfuscationReport struct {
+	TokensMapped  int
+	BodiesDropped uint64
+	KeyFile       string
+}
+
+// Edit reads the backup in srcDir, applies the options and writes a new
+// backup to dstDir, which must not exist or be an empty directory. The
+// output appears atomically: it is staged beside dstDir and renamed into
+// place only once the sentinel and meta file are on disk
+func Edit(ctx context.Context, srcDir string, dstDir string, opts ...EditOption) (*Result, error) {
+	o := &editOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	if err := o.validate(); err != nil {
+		return nil, err
+	}
+	src, err := openSource(srcDir)
+	if err != nil {
+		return nil, err
+	}
+	defer src.close()
+
+	if o.kvCompact && !src.isKVBucket() {
+		return nil, fmt.Errorf("KVCompact requires a KV bucket backup: stream %q with subjects %v is not one", src.metaFile.Config.Name, src.metaFile.Config.Subjects)
+	}
+
+	ed := &editor{ctx: ctx, o: o, src: src, cfg: src.metaFile.Config, now: time.Now()}
+	if o.obfuscate {
+		if ed.obf, err = newObfuscator(o.keyFile); err != nil {
+			return nil, err
+		}
+	}
+
+	var tgt *target
+	if !o.dryRun {
+		tgt, err = prepareTarget(dstDir)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if tgt != nil {
+				tgt.discard()
+			}
+		}()
+	}
+
+	if err := ed.run(tgt); err != nil {
+		return nil, err
+	}
+
+	result, err := ed.result()
+	if err != nil {
+		return nil, err
+	}
+	if tgt == nil {
+		return result, nil
+	}
+
+	mf := &metaFile{
+		Config: result.Config,
+		State:  result.State,
+		Edit: &EditInfo{
+			Version:      o.toolVersion,
+			Options:      o.canonical(),
+			SourceDigest: ed.digest,
+			Obfuscated:   o.obfuscate,
+		},
+	}
+	data, err := mf.marshal()
+	if err != nil {
+		return nil, err
+	}
+	if err := tgt.writeFile(MetaFile, data); err != nil {
+		return nil, err
+	}
+
+	if ed.obf != nil {
+		kf := keyFilePath(tgt.final)
+		created, err := ed.obf.writeKeyFile(kf, o.keyFile)
+		if err != nil {
+			return nil, err
+		}
+		if err := tgt.commit(); err != nil {
+			if created {
+				os.Remove(kf)
+			}
+			return nil, err
+		}
+		result.Report.Obfuscation.KeyFile = kf
+	} else if err := tgt.commit(); err != nil {
+		return nil, err
+	}
+	tgt = nil
+
+	return result, nil
+}
+
+type editor struct {
+	ctx      context.Context
+	o        *editOptions
+	src      *source
+	cfg      api.StreamConfig
+	now      time.Time
+	enc      *Encoder
+	obf      *obfuscator
+	srcState api.StreamState
+	firstOut uint64
+	bytes    uint64
+	overAge  uint64
+	digest   string
+	report   Report
+}
+
+func (e *editor) run(tgt *target) error {
+	pass := e.singlePass
+	if e.o.perSubject() {
+		pass = e.twoPass
+	}
+	if tgt == nil {
+		return pass()
+	}
+
+	out, err := os.OpenFile(tgt.path(DataFile), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	e.enc = NewEncoder(out)
+
+	if err := pass(); err != nil {
+		out.Close()
+		return err
+	}
+	if err := e.enc.Close(); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func (e *editor) singlePass() error {
+	dec := NewDecoder(e.src.tee)
+	for {
+		if err := e.ctx.Err(); err != nil {
+			return err
+		}
+
+		item, err := dec.Next()
+		if err != nil {
+			return err
+		}
+
+		switch it := item.(type) {
+		case *State:
+			e.srcState = it.State
+			if err := e.writeState(it.Ts, nil); err != nil {
+				return err
+			}
+		case *Consumer:
+			if err := e.consumer(it); err != nil {
+				return err
+			}
+		case *Message:
+			if err := e.filterMessage(it); err != nil {
+				return err
+			}
+		case End:
+			if e.enc != nil {
+				if err := e.enc.WriteEnd(); err != nil {
+					return err
+				}
+			}
+			e.digest, err = e.src.finishDigest()
+			return err
+		}
+	}
+}
+
+// writeState writes the leading state.json; exact carries the message and
+// byte totals when a pass already knows them, otherwise they are left at 0
+func (e *editor) writeState(ts int64, exact *api.StreamState) error {
+	st := api.StreamState{
+		FirstSeq:  e.srcState.FirstSeq,
+		LastSeq:   e.srcState.LastSeq,
+		Consumers: e.srcState.Consumers,
+	}
+	if e.o.renumber {
+		st.FirstSeq = 1
+		st.LastSeq = 0
+		st.Consumers = 0
+	}
+	if exact != nil {
+		st.Msgs = exact.Msgs
+		st.Bytes = exact.Bytes
+		if e.o.renumber {
+			st.LastSeq = exact.Msgs
+		}
+		if e.o.obfuscate {
+			st.Bytes = 0
+		}
+	}
+	if e.enc == nil {
+		return nil
+	}
+	return e.enc.WriteState(ts, st)
+}
+
+func (e *editor) consumer(c *Consumer) error {
+	if e.o.renumber {
+		e.report.ConsumersDropped++
+		return nil
+	}
+	e.report.ConsumersKept++
+	return e.writeConsumer(c)
+}
+
+func (e *editor) writeConsumer(c *Consumer) error {
+	name, data := c.Name, c.Data
+	if e.obf != nil {
+		var err error
+		if name, data, err = e.obf.consumer(c.Name, c.Data); err != nil {
+			return err
+		}
+	}
+	if e.enc == nil {
+		return nil
+	}
+	return e.enc.WriteConsumer(name, c.Ts, data)
+}
+
+// twoPass observes the filtered result per subject first and writes only
+// after the source sentinel was reached, so state.json carries exact totals.
+// The second pass rewinds the handle held since the first; it re-runs no
+// filters and must copy exactly what the first pass resolved. A plain dry
+// run stops after Resolve; an obfuscated dry run replays the second pass
+// without an encoder so the token and body counters match a real run
+func (e *editor) twoPass() error {
+	state := newSubjectState(e.o)
+	var passed uint64
+
+	dec := NewDecoder(e.src.tee)
+	for done := false; !done; {
+		if err := e.ctx.Err(); err != nil {
+			return err
+		}
+		item, err := dec.Next()
+		if err != nil {
+			return err
+		}
+
+		switch it := item.(type) {
+		case *State:
+			e.srcState = it.State
+		case *Consumer:
+			if e.o.renumber {
+				e.report.ConsumersDropped++
+			} else {
+				e.report.ConsumersKept++
+			}
+		case *Message:
+			ok, body, err := e.evaluate(it)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+			passed++
+			tomb := false
+			if e.o.kvCompact && it.HdrSize > 0 {
+				hdr, err := body.headers()
+				if err != nil {
+					return err
+				}
+				tomb = isTombstone(hdr)
+			}
+			state.Observe(it.Subject, it.Seq, storedMsgSize(len(it.Subject), it.HdrSize, it.PayloadSize), tomb)
+		case End:
+			if e.digest, err = e.src.finishDigest(); err != nil {
+				return err
+			}
+			done = true
+		}
+	}
+
+	res := state.Resolve()
+	if e.o.kvCompact {
+		e.report.Dropped.KVCompact = passed - res.msgs
+	} else {
+		e.report.Dropped.LastPerSubject = passed - res.msgs
+	}
+	e.report.SubjectStateKeys, e.report.SubjectStateBytes = state.Stats()
+
+	if e.enc == nil && e.obf == nil {
+		e.report.Kept, e.bytes, e.firstOut = res.msgs, res.bytes, res.firstSeq
+		return nil
+	}
+
+	if e.o.betweenPasses != nil {
+		e.o.betweenPasses()
+	}
+	r, err := e.src.rewind()
+	if err != nil {
+		return err
+	}
+
+	dec = NewDecoder(r)
+	for {
+		if err := e.ctx.Err(); err != nil {
+			return err
+		}
+		item, err := dec.Next()
+		if err != nil {
+			return err
+		}
+
+		switch it := item.(type) {
+		case *State:
+			if err := e.writeState(it.Ts, &api.StreamState{Msgs: res.msgs, Bytes: res.bytes}); err != nil {
+				return err
+			}
+		case *Consumer:
+			if e.o.renumber {
+				continue
+			}
+			if err := e.writeConsumer(it); err != nil {
+				return err
+			}
+		case *Message:
+			if !state.Keeps(it.Subject, it.Seq) {
+				continue
+			}
+			if err := e.writeMessage(&msgBody{m: it}); err != nil {
+				return err
+			}
+		case End:
+			if e.report.Kept != res.msgs || (e.obf == nil && e.bytes != res.bytes) {
+				return fmt.Errorf("second pass copied %d messages (%d bytes) but the first pass resolved %d (%d bytes): the source changed during the edit", e.report.Kept, e.bytes, res.msgs, res.bytes)
+			}
+			if e.enc == nil {
+				return nil
+			}
+			return e.enc.WriteEnd()
+		}
+	}
+}
+
+func (e *editor) filterMessage(m *Message) error {
+	ok, body, err := e.evaluate(m)
+	if err != nil || !ok {
+		return err
+	}
+	return e.writeMessage(body)
+}
+
+// evaluate applies the stateless filters; a rejected message is counted and reported as not ok
+func (e *editor) evaluate(m *Message) (bool, *msgBody, error) {
+	e.report.SourceMessages++
+	body := &msgBody{m: m}
+
+	kind := e.o.evalMeta(m)
+	if kind == keep && e.o.hasHeaderFilters() {
+		hdr, err := body.headers()
+		if err != nil {
+			return false, nil, err
+		}
+		kind = e.o.evalHeaders(hdr)
+	}
+	if kind == keep && e.o.hasPayloadFilters() {
+		payload, err := body.payload()
+		if err != nil {
+			return false, nil, err
+		}
+		kind = e.o.evalPayload(payload)
+	}
+	if kind != keep {
+		return false, body, e.drop(kind, body)
+	}
+
+	return true, body, nil
+}
+
+func (e *editor) drop(kind dropKind, body *msgBody) error {
+	e.report.Dropped.add(kind)
+	if !kind.contentFilter() || body.m.HdrSize == 0 {
+		return nil
+	}
+	hdr, err := body.headers()
+	if err != nil {
+		return err
+	}
+	if isTombstone(hdr) {
+		e.report.TombstonesRemovedByContentFilters++
+	}
+	return nil
+}
+
+func (e *editor) writeMessage(body *msgBody) error {
+	m := body.m
+	out := *m
+
+	if e.cfg.MaxAge > 0 && time.Unix(0, m.Ts).Add(e.cfg.MaxAge).Before(e.now) {
+		e.overAge++
+	}
+
+	if e.obf != nil {
+		hdr, err := body.headers()
+		if err != nil {
+			return err
+		}
+		subject, block, err := e.obf.message(m.Subject, hdr)
+		if err != nil {
+			return err
+		}
+		if m.PayloadSize > 0 {
+			e.obf.bodies++
+		}
+		out.Subject, out.HdrSize, out.PayloadSize, out.Body = subject, int64(len(block)), 0, bytes.NewReader(block)
+	} else {
+		out.Body = body.reader()
+	}
+
+	e.report.Kept++
+	if e.o.renumber {
+		out.Seq = e.report.Kept
+	}
+	if e.report.Kept == 1 {
+		e.firstOut = out.Seq
+	}
+	e.bytes += storedMsgSize(len(out.Subject), out.HdrSize, out.PayloadSize)
+	if e.enc == nil {
+		return nil
+	}
+
+	return e.enc.WriteMessage(&out)
+}
+
+// resultRange is the sequence range the restored stream will report: the
+// first kept sequence through the source's last (preserve) or K (renumber);
+// an edit that kept nothing restores as an empty stream at last+1/last
+func (e *editor) resultRange() (first uint64, last uint64) {
+	switch {
+	case e.o.renumber:
+		return 1, e.report.Kept
+	case e.report.Kept > 0:
+		return e.firstOut, e.srcState.LastSeq
+	case e.report.SourceMessages == 0:
+		return e.srcState.FirstSeq, e.srcState.LastSeq
+	default:
+		return e.srcState.LastSeq + 1, e.srcState.LastSeq
+	}
+}
+
+func (e *editor) result() (*Result, error) {
+	cfg := e.cfg
+	if e.o.renumber {
+		cfg.FirstSeq = 0
+	}
+	if e.obf != nil {
+		var err error
+		if cfg, err = e.obf.config(cfg); err != nil {
+			return nil, err
+		}
+		e.report.Obfuscation = &ObfuscationReport{TokensMapped: len(e.obf.reverse), BodiesDropped: e.obf.bodies}
+	}
+
+	st := api.StreamState{
+		Msgs:      e.report.Kept,
+		Bytes:     e.bytes,
+		Consumers: e.report.ConsumersKept,
+	}
+	st.FirstSeq, st.LastSeq = e.resultRange()
+
+	if cfg.MaxMsgs > 0 && e.report.Kept > uint64(cfg.MaxMsgs) {
+		e.warn("%d messages kept but max_msgs is %d: restore will discard the oldest %d", e.report.Kept, cfg.MaxMsgs, e.report.Kept-uint64(cfg.MaxMsgs))
+	}
+	if cfg.MaxBytes > 0 && e.bytes > uint64(cfg.MaxBytes) {
+		e.warn("%d bytes kept but max_bytes is %d: restore will discard the oldest messages", e.bytes, cfg.MaxBytes)
+	}
+	if cfg.MaxAge > 0 && e.overAge > 0 {
+		e.warn("%d kept messages are already older than max_age %s: restore will discard them", e.overAge, cfg.MaxAge)
+	}
+	if e.o.lastPerSubject > 0 && cfg.MaxMsgsPer > 0 && int64(e.o.lastPerSubject) > cfg.MaxMsgsPer {
+		e.warn("last-per-subject %d exceeds max_msgs_per_subject %d: restore will keep only %d per subject", e.o.lastPerSubject, cfg.MaxMsgsPer, cfg.MaxMsgsPer)
+	}
+
+	return &Result{Config: cfg, State: st, Report: e.report}, nil
+}
+
+func (e *editor) warn(format string, args ...any) {
+	e.report.Warnings = append(e.report.Warnings, fmt.Sprintf(format, args...))
+}

--- a/backup/edit_test.go
+++ b/backup/edit_test.go
@@ -1,0 +1,502 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+var fixtureMsgs = []testMsg{
+	{"orders.new", 2, 1_000, "", "order 1"},
+	{"orders.paid", 3, 2_000, "NATS/1.0\r\nX-Batch: 7\r\nX-Batch: 8\r\n\r\n", "paid 1"},
+	{"orders.new", 5, 3_000, "NATS/1.0\r\nKV-Operation: DEL\r\n\r\n", ""},
+	{"orders.shipped", 6, 4_000, "NATS/1.0\r\nNats-Marker-Reason: MaxAge\r\n\r\n", ""},
+	{"orders.new", 9, 5_000, "NATS/1.0\r\nNats-TTL: 1s\r\nX-Batch: 7\r\n\r\n", "order 2 urgent"},
+	{"audit.log", 10, 6_000, "", "audit entry"},
+	{"orders.paid", 12, 7_000, "NATS/1.0\r\nKV-Operation: PUT\r\nNats-Marker-Reason: Remove\r\n\r\n", "paid urgent"},
+}
+
+func fixtureState() api.StreamState {
+	return api.StreamState{Msgs: 7, Bytes: 12345, FirstSeq: 2, LastSeq: 14, Consumers: 2, NumDeleted: 3, Deleted: []uint64{4, 7, 8}}
+}
+
+func fixtureConfig() api.StreamConfig {
+	return api.StreamConfig{Name: "ORDERS", Subjects: []string{"orders.>", "audit.*"}, Storage: api.FileStorage, Retention: api.LimitsPolicy, FirstSeq: 2}
+}
+
+func fixtureDir(t *testing.T, cfg api.StreamConfig, msgs []testMsg) string {
+	t.Helper()
+	return fixtureDirWithState(t, cfg, fixtureState(), msgs)
+}
+
+func fixtureDirWithState(t *testing.T, cfg api.StreamConfig, st api.StreamState, msgs []testMsg) string {
+	t.Helper()
+	consumers := map[string][]byte{"c1": consumerJSON(t, "c1"), "c2": consumerJSON(t, "c2")}
+	dir := filepath.Join(t.TempDir(), "src")
+	writeBackupDir(t, dir, cfg, st, encodeBackup(t, st, consumers, msgs, true))
+	return dir
+}
+
+func readItems(t *testing.T, dir string) []Item {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, DataFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, err := decodeAll(t, data)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	return items
+}
+
+func loadMetaFile(t *testing.T, dir string) *metaFile {
+	t.Helper()
+	sc, err := readMetaFile(filepath.Join(dir, MetaFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sc
+}
+
+func messagesOf(items []Item) []*Message {
+	var out []*Message
+	for _, it := range items {
+		if m, ok := it.(*Message); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func consumersOf(items []Item) []*Consumer {
+	var out []*Consumer
+	for _, it := range items {
+		if c, ok := it.(*Consumer); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func seqsOf(msgs []*Message) []uint64 {
+	out := make([]uint64, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Seq)
+	}
+	return out
+}
+
+func sameMessage(a, b *Message) bool {
+	ab, _ := io.ReadAll(a.Body)
+	bb, _ := io.ReadAll(b.Body)
+	a.Body, b.Body = bytes.NewReader(ab), bytes.NewReader(bb)
+	return a.Subject == b.Subject && a.Seq == b.Seq && a.Ts == b.Ts && a.HdrSize == b.HdrSize && a.PayloadSize == b.PayloadSize && bytes.Equal(ab, bb)
+}
+
+func edit(t *testing.T, src string, opts ...EditOption) (string, *Result) {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), "dst")
+	res, err := Edit(context.Background(), src, dst, opts...)
+	if err != nil {
+		t.Fatalf("edit failed: %v", err)
+	}
+	return dst, res
+}
+
+func TestEditIdentity(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	dst, res := edit(t, src)
+
+	if _, err := Verify(dst); err != nil {
+		t.Fatalf("output does not verify: %v", err)
+	}
+
+	in, out := readItems(t, src), readItems(t, dst)
+	if len(in) != len(out) {
+		t.Fatalf("item count differs: %d vs %d", len(in), len(out))
+	}
+
+	inState, outState := in[0].(*State), out[0].(*State)
+	if outState.Ts != inState.Ts {
+		t.Fatalf("state timestamp not copied")
+	}
+	want := api.StreamState{FirstSeq: 2, LastSeq: 14, Consumers: 2}
+	if !reflect.DeepEqual(outState.State, want) {
+		t.Fatalf("archive state %+v, want %+v", outState.State, want)
+	}
+
+	for i := range in[1:] {
+		a, b := in[1+i], out[1+i]
+		switch x := a.(type) {
+		case *Consumer:
+			y := b.(*Consumer)
+			if x.Name != y.Name || x.Ts != y.Ts || !bytes.Equal(x.Data, y.Data) {
+				t.Fatalf("consumer %d differs", i)
+			}
+		case *Message:
+			if !sameMessage(x, b.(*Message)) {
+				t.Fatalf("message %d differs: %+v vs %+v", i, x, b)
+			}
+		case End:
+			if _, ok := b.(End); !ok {
+				t.Fatalf("expected End, got %T", b)
+			}
+		}
+	}
+
+	srcBytes, _ := os.ReadFile(filepath.Join(src, DataFile))
+	sum := sha256.Sum256(srcBytes)
+	sc := loadMetaFile(t, dst)
+	if sc.Edit == nil || sc.Edit.SourceDigest != "sha256:"+hex.EncodeToString(sum[:]) {
+		t.Fatalf("unexpected edit block: %+v", sc.Edit)
+	}
+	if sc.Edit.Version != "" || len(sc.Edit.Options) != 0 || sc.Edit.Obfuscated {
+		t.Fatalf("unexpected edit block: %+v", sc.Edit)
+	}
+	rawMeta, _ := os.ReadFile(filepath.Join(dst, MetaFile))
+	if strings.Contains(string(rawMeta), "version") {
+		t.Fatal("edit block must omit the version when none was given")
+	}
+	if !reflect.DeepEqual(sc.Config, fixtureConfig()) {
+		t.Fatalf("config not copied verbatim: %+v", sc.Config)
+	}
+	var wantBytes uint64
+	for _, m := range fixtureMsgs {
+		wantBytes += storedMsgSize(len(m.subject), int64(len(m.hdr)), int64(len(m.body)))
+	}
+	wantMeta := api.StreamState{Msgs: 7, Bytes: wantBytes, FirstSeq: 2, LastSeq: 14, Consumers: 2}
+	if !reflect.DeepEqual(sc.State, wantMeta) || !reflect.DeepEqual(res.State, wantMeta) {
+		t.Fatalf("meta file state %+v, result %+v, want %+v", sc.State, res.State, wantMeta)
+	}
+
+	rep := res.Report
+	if rep.SourceMessages != 7 || rep.Kept != 7 || rep.Dropped.Total() != 0 || rep.ConsumersKept != 2 || rep.ConsumersDropped != 0 || rep.TombstonesRemovedByContentFilters != 0 {
+		t.Fatalf("unexpected report: %+v", rep)
+	}
+}
+
+func TestEditDeterministic(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	opts := []EditOption{Subjects("orders.>"), HeaderValue("X-Batch", "7"), LastSeq(12)}
+
+	a, _ := edit(t, src, opts...)
+	b, _ := edit(t, src, LastSeq(12), HeaderValue("X-Batch", "7"), Subjects("orders.>"))
+
+	for _, name := range []string{DataFile, MetaFile} {
+		x, _ := os.ReadFile(filepath.Join(a, name))
+		y, _ := os.ReadFile(filepath.Join(b, name))
+		if !bytes.Equal(x, y) {
+			t.Fatalf("%s differs between two identical edits", name)
+		}
+	}
+
+	sc := loadMetaFile(t, a)
+	want := []string{"subject=orders.>", "last-seq=12", "header=X-Batch:7"}
+	if !reflect.DeepEqual(sc.Edit.Options, want) {
+		t.Fatalf("canonical options %v, want %v", sc.Edit.Options, want)
+	}
+}
+
+func TestEditDryRun(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	dst := filepath.Join(t.TempDir(), "dry")
+
+	dry, err := Edit(context.Background(), src, dst, ExcludeSubjects("audit.*"), Renumber(), DryRun())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dst); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry run created the target: %v", err)
+	}
+	if entries, _ := os.ReadDir(filepath.Dir(dst)); len(entries) != 0 {
+		t.Fatalf("dry run left files behind: %v", entries)
+	}
+
+	_, real := edit(t, src, ExcludeSubjects("audit.*"), Renumber())
+	if !reflect.DeepEqual(dry, real) {
+		t.Fatalf("dry run result differs:\n%+v\n%+v", dry, real)
+	}
+}
+
+func TestEditTargetRules(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+
+	full := filepath.Join(t.TempDir(), "full")
+	os.MkdirAll(full, 0o700)
+	os.WriteFile(filepath.Join(full, "x"), []byte("x"), 0o600)
+	if _, err := Edit(context.Background(), src, full); err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("expected a non-empty target error, got %v", err)
+	}
+
+	file := filepath.Join(t.TempDir(), "file")
+	os.WriteFile(file, []byte("x"), 0o600)
+	if _, err := Edit(context.Background(), src, file); err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("expected a not-a-directory error, got %v", err)
+	}
+
+	empty := filepath.Join(t.TempDir(), "empty")
+	os.MkdirAll(empty, 0o700)
+	if _, err := Edit(context.Background(), src, empty); err != nil {
+		t.Fatalf("empty existing dir should be accepted: %v", err)
+	}
+	if _, err := Verify(empty); err != nil {
+		t.Fatal(err)
+	}
+
+	nested := filepath.Join(t.TempDir(), "a", "b", "c")
+	if _, err := Edit(context.Background(), src, nested); err != nil {
+		t.Fatalf("missing parents should be created: %v", err)
+	}
+	if entries, _ := os.ReadDir(filepath.Dir(nested)); len(entries) != 1 {
+		t.Fatalf("staging directory left behind: %v", entries)
+	}
+}
+
+func TestEditFailureLeavesNothing(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	data, _ := os.ReadFile(filepath.Join(src, DataFile))
+	if err := os.WriteFile(filepath.Join(src, DataFile), data[:len(data)-40], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "dst")
+	_, err := Edit(context.Background(), src, dst)
+	if err == nil {
+		t.Fatal("expected the truncated source to fail")
+	}
+	entries, _ := os.ReadDir(parent)
+	if len(entries) != 0 {
+		t.Fatalf("failed edit left files behind: %v", entries)
+	}
+}
+
+func TestEditContextCancelled(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Edit(ctx, src, filepath.Join(t.TempDir(), "dst"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestEditOptionValidation(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	now := time.Now()
+	cases := map[string]struct {
+		opts []EditOption
+		want string
+	}{
+		"bad subject":         {[]EditOption{Subjects("a..b")}, `invalid subject filter "a..b"`},
+		"bad exclude":         {[]EditOption{ExcludeSubjects("")}, "invalid subject filter"},
+		"after not before":    {[]EditOption{After(now), Before(now)}, "After must be earlier than Before"},
+		"after out of range":  {[]EditOption{After(time.Date(2500, 1, 1, 0, 0, 0, 0, time.UTC))}, "outside the supported time range"},
+		"before out of range": {[]EditOption{Before(time.Date(1500, 1, 1, 0, 0, 0, 0, time.UTC))}, "outside the supported time range"},
+		"seq range":           {[]EditOption{FirstSeq(10), LastSeq(5)}, "FirstSeq 10 is above LastSeq 5"},
+		"bad header":          {[]EditOption{HeaderPresent("a:b")}, `invalid header name "a:b"`},
+		"bad header value":    {[]EditOption{HeaderValue("a", "x\r\n")}, "invalid header value"},
+		"nil regex":           {[]EditOption{PayloadMatch(nil)}, "payload expression is nil"},
+		"last per subject":    {[]EditOption{LastPerSubject(-1)}, "LastPerSubject requires at least 1"},
+		"last per subject 0":  {[]EditOption{LastPerSubject(0)}, "LastPerSubject requires at least 1"},
+		"compact and last":    {[]EditOption{KVCompact(), LastPerSubject(2)}, "mutually exclusive"},
+		"key without obf":     {[]EditOption{ObfuscationKeyFile("x")}, "ObfuscationKeyFile requires Obfuscate"},
+		"kv compact on plain": {[]EditOption{KVCompact()}, "KVCompact requires a KV bucket backup"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Edit(context.Background(), src, filepath.Join(t.TempDir(), "dst"), tc.opts...)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q, got %v", tc.want, err)
+			}
+		})
+	}
+
+	if _, err := Edit(context.Background(), t.TempDir(), filepath.Join(t.TempDir(), "dst")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected a missing source error, got %v", err)
+	}
+}
+
+func TestEditFilters(t *testing.T) {
+	cases := map[string]struct {
+		opts    []EditOption
+		seqs    []uint64
+		dropped DropCounts
+		tombs   uint64
+	}{
+		"subjects or":          {[]EditOption{Subjects("orders.new", "audit.>")}, []uint64{2, 5, 9, 10}, DropCounts{Subject: 3}, 0},
+		"subject wildcard":     {[]EditOption{Subjects("orders.*")}, []uint64{2, 3, 5, 6, 9, 12}, DropCounts{Subject: 1}, 0},
+		"exclude veto":         {[]EditOption{Subjects("orders.>"), ExcludeSubjects("orders.paid")}, []uint64{2, 5, 6, 9}, DropCounts{Subject: 3}, 0},
+		"exclude only":         {[]EditOption{ExcludeSubjects("orders.new", "orders.paid")}, []uint64{6, 10}, DropCounts{Subject: 5}, 0},
+		"after inclusive":      {[]EditOption{After(time.Unix(0, 3_000))}, []uint64{5, 6, 9, 10, 12}, DropCounts{Time: 2}, 0},
+		"before exclusive":     {[]EditOption{Before(time.Unix(0, 3_000))}, []uint64{2, 3}, DropCounts{Time: 5}, 0},
+		"window":               {[]EditOption{After(time.Unix(0, 2_000)), Before(time.Unix(0, 6_000))}, []uint64{3, 5, 6, 9}, DropCounts{Time: 3}, 0},
+		"sequence range":       {[]EditOption{FirstSeq(5), LastSeq(10)}, []uint64{5, 6, 9, 10}, DropCounts{Sequence: 3}, 0},
+		"first seq only":       {[]EditOption{FirstSeq(10)}, []uint64{10, 12}, DropCounts{Sequence: 5}, 0},
+		"header present":       {[]EditOption{HeaderPresent("x-batch")}, []uint64{3, 9}, DropCounts{Header: 5}, 2},
+		"header value any":     {[]EditOption{HeaderValue("X-BATCH", "8")}, []uint64{3}, DropCounts{Header: 6}, 2},
+		"header positives or":  {[]EditOption{HeaderPresent("Nats-TTL"), HeaderValue("KV-Operation", "DEL")}, []uint64{5, 9}, DropCounts{Header: 5}, 1},
+		"no header veto":       {[]EditOption{NoHeader("kv-operation"), NoHeader("nats-marker-reason")}, []uint64{2, 3, 9, 10}, DropCounts{Header: 3}, 2},
+		"header and no header": {[]EditOption{HeaderPresent("X-Batch"), NoHeader("Nats-TTL")}, []uint64{3}, DropCounts{Header: 6}, 2},
+		"payload match":        {[]EditOption{PayloadMatch(regexp.MustCompile("urgent"))}, []uint64{9, 12}, DropCounts{Payload: 5}, 2},
+		"payload or":           {[]EditOption{PayloadMatch(regexp.MustCompile("^order 1$")), PayloadMatch(regexp.MustCompile("audit"))}, []uint64{2, 10}, DropCounts{Payload: 5}, 2},
+		"payload exclude":      {[]EditOption{ExcludePayloadMatch(regexp.MustCompile("paid"))}, []uint64{2, 5, 6, 9, 10}, DropCounts{Payload: 2}, 0},
+		"payload empty body":   {[]EditOption{PayloadMatch(regexp.MustCompile("^$"))}, []uint64{5, 6}, DropCounts{Payload: 5}, 0},
+		"and across kinds":     {[]EditOption{Subjects("orders.>"), FirstSeq(3), Before(time.Unix(0, 7_000)), HeaderPresent("X-Batch"), PayloadMatch(regexp.MustCompile("urgent"))}, []uint64{9}, DropCounts{Sequence: 1, Time: 1, Subject: 1, Header: 2, Payload: 1}, 2},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+			dst, res := edit(t, src, tc.opts...)
+			if _, err := Verify(dst); err != nil {
+				t.Fatalf("output does not verify: %v", err)
+			}
+			got := seqsOf(messagesOf(readItems(t, dst)))
+			if !reflect.DeepEqual(got, tc.seqs) {
+				t.Fatalf("kept %v, want %v", got, tc.seqs)
+			}
+			if res.Report.Dropped != tc.dropped || res.Report.Kept != uint64(len(tc.seqs)) || res.Report.SourceMessages != 7 {
+				t.Fatalf("report %+v, want dropped %+v", res.Report, tc.dropped)
+			}
+			if res.Report.TombstonesRemovedByContentFilters != tc.tombs {
+				t.Fatalf("tombstones removed by content filters %d, want %d", res.Report.TombstonesRemovedByContentFilters, tc.tombs)
+			}
+			if res.State.Msgs != uint64(len(tc.seqs)) || res.State.FirstSeq != tc.seqs[0] || res.State.LastSeq != 14 || res.State.Consumers != 2 {
+				t.Fatalf("unexpected meta file state: %+v", res.State)
+			}
+		})
+	}
+}
+
+func TestEditRenumber(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	dst, res := edit(t, src, ExcludeSubjects("orders.new"), Renumber())
+
+	items := readItems(t, dst)
+	st := items[0].(*State).State
+	if !reflect.DeepEqual(st, api.StreamState{FirstSeq: 1, LastSeq: 0}) {
+		t.Fatalf("archive state %+v", st)
+	}
+	if len(consumersOf(items)) != 0 {
+		t.Fatal("consumers should be dropped under renumber")
+	}
+	msgs := messagesOf(items)
+	if !reflect.DeepEqual(seqsOf(msgs), []uint64{1, 2, 3, 4}) {
+		t.Fatalf("unexpected seqs %v", seqsOf(msgs))
+	}
+	if msgs[0].Subject != "orders.paid" || msgs[0].Ts != 2_000 || msgs[3].Subject != "orders.paid" || msgs[3].Ts != 7_000 {
+		t.Fatalf("message identity changed: %+v %+v", msgs[0], msgs[3])
+	}
+	if res.State.FirstSeq != 1 || res.State.LastSeq != 4 || res.State.Msgs != 4 || res.State.Consumers != 0 {
+		t.Fatalf("unexpected meta file state %+v", res.State)
+	}
+	if res.Config.FirstSeq != 0 || loadMetaFile(t, dst).Config.FirstSeq != 0 {
+		t.Fatal("renumber must clear StreamConfig.FirstSeq")
+	}
+	if res.Report.ConsumersDropped != 2 || res.Report.ConsumersKept != 0 {
+		t.Fatalf("unexpected consumer counts %+v", res.Report)
+	}
+}
+
+func TestEditEmptyResult(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+
+	dst, res := edit(t, src, Subjects("nothing.matches"))
+	items := readItems(t, dst)
+	if len(messagesOf(items)) != 0 || len(consumersOf(items)) != 2 {
+		t.Fatalf("unexpected items: %d", len(items))
+	}
+	st := items[0].(*State).State
+	if st.FirstSeq != 2 || st.LastSeq != 14 || st.Consumers != 2 {
+		t.Fatalf("preserve must copy the source range: %+v", st)
+	}
+	if res.State.Msgs != 0 || res.State.Bytes != 0 || res.State.FirstSeq != 15 || res.State.LastSeq != 14 {
+		t.Fatalf("meta file must describe the restored empty stream at last+1/last: %+v", res.State)
+	}
+
+	dst, res = edit(t, src, Subjects("nothing.matches"), Renumber())
+	st = readItems(t, dst)[0].(*State).State
+	if st.FirstSeq != 1 || st.LastSeq != 0 || res.State.FirstSeq != 1 || res.State.LastSeq != 0 {
+		t.Fatalf("renumber empty result: archive %+v meta file %+v", st, res.State)
+	}
+}
+
+func TestEditWarnings(t *testing.T) {
+	cfg := fixtureConfig()
+	cfg.MaxMsgs = 3
+	cfg.MaxBytes = 100
+	cfg.MaxAge = time.Hour
+	src := fixtureDir(t, cfg, fixtureMsgs)
+
+	_, res := edit(t, src)
+	joined := strings.Join(res.Report.Warnings, "\n")
+	for _, want := range []string{"7 messages kept but max_msgs is 3", "max_bytes is 100", "7 kept messages are already older than max_age 1h0m0s"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing warning %q in %q", want, joined)
+		}
+	}
+
+	_, res = edit(t, fixtureDir(t, fixtureConfig(), fixtureMsgs))
+	if len(res.Report.Warnings) != 0 {
+		t.Fatalf("unexpected warnings %v", res.Report.Warnings)
+	}
+}
+
+func TestEditMetaFileShape(t *testing.T) {
+	src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+	dst, _ := edit(t, src, FirstSeq(3), ToolVersion("nats 9.9.9"))
+
+	if v := loadMetaFile(t, dst).Edit.Version; v != "nats 9.9.9" {
+		t.Fatalf("caller version not recorded: %q", v)
+	}
+
+	raw, _ := os.ReadFile(filepath.Join(dst, MetaFile))
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"config", "state", "edit"} {
+		if _, ok := generic[key]; !ok {
+			t.Fatalf("meta file lacks %q: %s", key, raw)
+		}
+	}
+
+	var req api.JSApiStreamRestoreRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("restore readers must still parse the meta file: %v", err)
+	}
+	if req.Config.Name != "ORDERS" || req.State.Msgs != 6 {
+		t.Fatalf("unexpected restore request: %+v", req)
+	}
+	if strings.Contains(string(raw), "T") && strings.Contains(string(raw), "time") {
+		t.Fatalf("meta file must not carry timestamps: %s", raw)
+	}
+}

--- a/backup/encoder.go
+++ b/backup/encoder.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/nats-io/nats-server/v2/server/archive"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+// Encoder writes a compressed NATSARC1 stream backup with the same framing
+// as the server: one archive entry per item, flushed individually so every
+// entry starts its own s2 block
+type Encoder struct {
+	s2w *s2.Writer
+	aw  *archive.Writer
+	buf []byte
+}
+
+// NewEncoder writes the s2 compressed archive to w
+func NewEncoder(w io.Writer) *Encoder {
+	s2w := s2.NewWriter(w)
+	return &Encoder{s2w: s2w, aw: archive.NewWriter(s2w), buf: make([]byte, 64*1024)}
+}
+
+// WriteState writes the leading state.json entry
+func (e *Encoder) WriteState(ts int64, st api.StreamState) error {
+	data, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	return e.writeEntry(stateEntry, ts, data)
+}
+
+// WriteConsumer writes one consumers/<name> entry
+func (e *Encoder) WriteConsumer(name string, ts int64, data []byte) error {
+	return e.writeEntry(path.Join("consumers", name), ts, data)
+}
+
+// WriteMessage writes one message, streaming exactly HdrSize+PayloadSize bytes from Body
+func (e *Encoder) WriteMessage(m *Message) error {
+	hdr := &archive.Header{
+		Name:        m.Subject,
+		Timestamp:   m.Ts,
+		Sequence:    m.Seq,
+		HeaderSize:  m.HdrSize,
+		PayloadSize: m.PayloadSize,
+	}
+	if err := e.aw.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	want := m.HdrSize + m.PayloadSize
+	if want > 0 {
+		n, err := io.CopyBuffer(e.aw, io.LimitReader(m.Body, want), e.buf)
+		if err != nil {
+			return err
+		}
+		if n != want {
+			return fmt.Errorf("message %s seq %d: body is %d bytes, %d declared", m.Subject, m.Seq, n, want)
+		}
+	}
+
+	return e.aw.Flush()
+}
+
+// WriteEnd writes the end-of-backup sentinel
+func (e *Encoder) WriteEnd() error {
+	return e.writeEntry("", 0, nil)
+}
+
+// Close finishes the archive and the compressed stream
+func (e *Encoder) Close() error {
+	if err := e.aw.Close(); err != nil {
+		return err
+	}
+	return e.s2w.Close()
+}
+
+func (e *Encoder) writeEntry(name string, ts int64, data []byte) error {
+	hdr := &archive.Header{
+		Name:        name,
+		Timestamp:   ts,
+		PayloadSize: int64(len(data)),
+	}
+	if err := e.aw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if _, err := e.aw.Write(data); err != nil {
+		return err
+	}
+	return e.aw.Flush()
+}

--- a/backup/filter.go
+++ b/backup/filter.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+type dropKind int
+
+const (
+	keep dropKind = iota
+	dropSequence
+	dropTime
+	dropSubject
+	dropHeader
+	dropPayload
+	dropLastPerSubject
+	dropKVCompact
+)
+
+func (k dropKind) contentFilter() bool {
+	return k == dropHeader || k == dropPayload
+}
+
+// evalMeta applies the filters that need only the entry header, cheapest first
+func (o *editOptions) evalMeta(m *Message) dropKind {
+	if (o.hasFirstSeq && m.Seq < o.firstSeq) || (o.hasLastSeq && m.Seq > o.lastSeq) {
+		return dropSequence
+	}
+	if (o.hasAfter && m.Ts < o.after.UnixNano()) || (o.hasBefore && m.Ts >= o.before.UnixNano()) {
+		return dropTime
+	}
+	if matchesAny(o.excludeSubjects, m.Subject) {
+		return dropSubject
+	}
+	if len(o.subjects) > 0 && !matchesAny(o.subjects, m.Subject) {
+		return dropSubject
+	}
+	return keep
+}
+
+func matchesAny(patterns []string, subject string) bool {
+	for _, p := range patterns {
+		if server.SubjectsCollide(p, subject) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *editOptions) evalHeaders(h nats.Header) dropKind {
+	for _, name := range o.noHeader {
+		if len(headerValues(h, name)) > 0 {
+			return dropHeader
+		}
+	}
+	if len(o.headerPresent)+len(o.headerValues) == 0 {
+		return keep
+	}
+	for _, name := range o.headerPresent {
+		if len(headerValues(h, name)) > 0 {
+			return keep
+		}
+	}
+	for _, hm := range o.headerValues {
+		if slices.Contains(headerValues(h, hm.name), hm.value) {
+			return keep
+		}
+	}
+	return dropHeader
+}
+
+func (o *editOptions) evalPayload(payload []byte) dropKind {
+	for _, re := range o.excludePayloadMatch {
+		if re.Match(payload) {
+			return dropPayload
+		}
+	}
+	if len(o.payloadMatch) == 0 {
+		return keep
+	}
+	for _, re := range o.payloadMatch {
+		if re.Match(payload) {
+			return keep
+		}
+	}
+	return dropPayload
+}
+
+// msgBody buffers a prefix of a message entry on demand so filters can look
+// at the headers or payload while the remainder still streams to the encoder
+type msgBody struct {
+	m       *Message
+	buf     []byte
+	hdr     nats.Header
+	decoded bool
+}
+
+func (b *msgBody) prefix(n int64) ([]byte, error) {
+	if int64(len(b.buf)) >= n {
+		return b.buf[:n], nil
+	}
+	grown := make([]byte, n)
+	copy(grown, b.buf)
+	if _, err := io.ReadFull(b.m.Body, grown[len(b.buf):]); err != nil {
+		return nil, fmt.Errorf("reading message %s seq %d: %w", b.m.Subject, b.m.Seq, err)
+	}
+	b.buf = grown
+	return b.buf, nil
+}
+
+// headers decodes the header block once; a message without headers yields nil
+func (b *msgBody) headers() (nats.Header, error) {
+	if b.decoded {
+		return b.hdr, nil
+	}
+	if b.m.HdrSize > 0 {
+		raw, err := b.prefix(b.m.HdrSize)
+		if err != nil {
+			return nil, err
+		}
+		if b.hdr, err = nats.DecodeHeadersMsg(raw); err != nil {
+			return nil, fmt.Errorf("message %s seq %d: %w", b.m.Subject, b.m.Seq, err)
+		}
+	}
+	b.decoded = true
+	return b.hdr, nil
+}
+
+func (b *msgBody) payload() ([]byte, error) {
+	all, err := b.prefix(b.m.HdrSize + b.m.PayloadSize)
+	if err != nil {
+		return nil, err
+	}
+	return all[b.m.HdrSize:], nil
+}
+
+func (b *msgBody) reader() io.Reader {
+	if len(b.buf) == 0 {
+		return b.m.Body
+	}
+	return io.MultiReader(bytes.NewReader(b.buf), b.m.Body)
+}

--- a/backup/headers.go
+++ b/backup/headers.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"strings"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+// the server exports only the PURGE operation value; nats.go keeps DEL unexported
+const kvOperationDelete = "DEL"
+
+// headerValues collects the values of every header whose name matches
+// case-insensitively, the way filter names are typed; server defined headers
+// are looked up exact-case with Get, as the server and nats.go do
+func headerValues(h nats.Header, name string) []string {
+	var out []string
+	for k, v := range h {
+		if strings.EqualFold(k, name) {
+			out = append(out, v...)
+		}
+	}
+	return out
+}
+
+// isTombstone mirrors nats.go's KV entry decoding: a KV-Operation header
+// decides when present, otherwise a limit marker reason does
+func isTombstone(h nats.Header) bool {
+	if op := h.Get(server.KVOperation); op != "" {
+		return op == kvOperationDelete || op == string(server.KVOperationValuePurge)
+	}
+	switch h.Get(server.JSMarkerReason) {
+	case server.JSMarkerReasonMaxAge, server.JSMarkerReasonPurge, server.JSMarkerReasonRemove:
+		return true
+	}
+	return false
+}

--- a/backup/metafile.go
+++ b/backup/metafile.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/jsm.go/api"
+)
+
+// EditInfo is the "edit" block an edited backup carries in its meta file.
+// An edited backup is a derived artifact and this block is its provenance:
+// SourceDigest is sha256 of the source stream.tar.s2, hashed while pass 1
+// streams it, so with the recorded options and tool version anyone holding
+// the source can re-run the edit, expect byte-identical output, and settle
+// which archive a shared backup was derived from. The digest is deliberate
+// under --obfuscate: it confirms to someone already holding the original
+// that the scrubbed copy came from it, and reveals nothing to anyone else
+type EditInfo struct {
+	Version      string   `json:"version,omitempty"`
+	Options      []string `json:"options"`
+	SourceDigest string   `json:"source_digest"`
+	Obfuscated   bool     `json:"obfuscated,omitempty"`
+}
+
+type metaFile struct {
+	Config api.StreamConfig `json:"config"`
+	State  api.StreamState  `json:"state"`
+	Edit   *EditInfo        `json:"edit,omitempty"`
+}
+
+func readMetaFile(path string) (*metaFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var mf metaFile
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if mf.Config.Name == "" {
+		return nil, fmt.Errorf("%s: config has no stream name", path)
+	}
+	if !jsm.IsValidName(mf.Config.Name) {
+		return nil, fmt.Errorf("%s: invalid stream name %q", path, mf.Config.Name)
+	}
+	if mf.Config.Storage == api.MemoryStorage {
+		return nil, fmt.Errorf("%s: %w", path, jsm.ErrMemoryStreamNotSupported)
+	}
+
+	return &mf, nil
+}
+
+func (mf *metaFile) marshal() ([]byte, error) {
+	return json.MarshalIndent(mf, "", "  ")
+}

--- a/backup/obfuscate.go
+++ b/backup/obfuscate.go
@@ -1,0 +1,457 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+const (
+	keyFileSuffix  = ".keys.json"
+	keyFileVersion = 1
+	secretBytes    = 32
+	tokenBytes     = 10
+	objStorePrefix = "OBJ_"
+	kvSubjectRoot  = "$KV"
+	objSubjectRoot = "$O"
+)
+
+var tokenEncoding = base32.HexEncoding.WithPadding(base32.NoPadding)
+
+// obfuscationKeyFile is the sensitive companion of an obfuscated backup: the
+// secret behind the token hashes and the reverse mapping
+type obfuscationKeyFile struct {
+	Version int               `json:"version"`
+	Secret  string            `json:"secret"`
+	Map     map[string]string `json:"map"`
+}
+
+// obfuscator replaces identifying tokens with keyed hashes. The same secret
+// and token always produce the same hash, so relations between subjects,
+// filters and names survive.
+//
+// The hash is HMAC-SHA-256 under a random 32-byte secret. Tokens are
+// low-entropy words like "orders", so an unkeyed hash is reversed by hashing
+// a wordlist. With the secret, recovery needs the key file. A random token
+// per original would obfuscate too, but its output depends on RNG and
+// encounter order, and an edit guarantees byte-identical output for the same
+// source, options and key file. The secret alone also keeps separate backups
+// consistent: two edits sharing a key file hash a common token identically
+// even when neither saw the other's map, and loading a key file re-verifies
+// every mapping against the secret, so a tampered or mismatched file is
+// rejected instead of producing conflicting tokens.
+//
+// Truncating to 10 bytes and encoding lowercase base32-hex gives a
+// 16-character token that is legal everywhere an original can appear: a
+// subject token, a KV key segment, a stream or consumer name. Stream names
+// become directories in the file store, so mixed case would collide on
+// case-insensitive filesystems, and base64 uses '/' and '+'. Hex needs 20
+// characters for the same bytes, and the subject is rewritten in every
+// message record, so token length inflates the archive. A collision within
+// 80 bits needs around a trillion distinct tokens, and token() fails on one
+// anyway instead of silently merging two originals
+type obfuscator struct {
+	secret  []byte
+	forward map[string]string
+	reverse map[string]string
+	bodies  uint64
+}
+
+func newObfuscator(keyFile string) (*obfuscator, error) {
+	o := &obfuscator{forward: map[string]string{}, reverse: map[string]string{}}
+	if keyFile == "" {
+		o.secret = make([]byte, secretBytes)
+		if _, err := rand.Read(o.secret); err != nil {
+			return nil, err
+		}
+		return o, nil
+	}
+
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	var kf obfuscationKeyFile
+	if err := json.Unmarshal(data, &kf); err != nil {
+		return nil, fmt.Errorf("%s: %w", keyFile, err)
+	}
+	if kf.Version != keyFileVersion {
+		return nil, fmt.Errorf("%s: unsupported key file version %d", keyFile, kf.Version)
+	}
+	o.secret, err = base64.StdEncoding.DecodeString(kf.Secret)
+	if err != nil || len(o.secret) != secretBytes {
+		return nil, fmt.Errorf("%s: invalid secret", keyFile)
+	}
+	for hashed, original := range kf.Map {
+		if o.hash(original) != hashed {
+			return nil, fmt.Errorf("%s: mapping for %q does not match the secret", keyFile, hashed)
+		}
+		o.forward[original] = hashed
+		o.reverse[hashed] = original
+	}
+
+	return o, nil
+}
+
+func (o *obfuscator) hash(tok string) string {
+	mac := hmac.New(sha256.New, o.secret)
+	mac.Write([]byte(tok))
+	return strings.ToLower(tokenEncoding.EncodeToString(mac.Sum(nil)[:tokenBytes]))
+}
+
+func (o *obfuscator) token(tok string) (string, error) {
+	if tok == "" {
+		return tok, nil
+	}
+	if h, ok := o.forward[tok]; ok {
+		return h, nil
+	}
+	h := o.hash(tok)
+	if other, taken := o.reverse[h]; taken && other != tok {
+		return "", fmt.Errorf("obfuscation hash collision between %q and %q", tok, other)
+	}
+	o.forward[tok] = h
+	o.reverse[h] = tok
+	return h, nil
+}
+
+// subject hashes a subject token by token; wildcards and the $KV and $O
+// roots pass through so filters keep their relations to the hashed subjects
+func (o *obfuscator) subject(subj string) (string, error) {
+	return o.rewriteSubject(subj, false)
+}
+
+// destination additionally passes {{...}} mapping functions through; only
+// republish and subject transform destinations carry them, anywhere else a
+// {{...}} token is literal subject text and subject hashes it
+func (o *obfuscator) destination(subj string) (string, error) {
+	return o.rewriteSubject(subj, true)
+}
+
+func (o *obfuscator) rewriteSubject(subj string, mappingFuncs bool) (string, error) {
+	if subj == "" {
+		return subj, nil
+	}
+	toks := strings.Split(subj, ".")
+	for i, tok := range toks {
+		switch {
+		case tok == "*", tok == ">", tok == kvSubjectRoot, tok == objSubjectRoot:
+		case mappingFuncs && strings.HasPrefix(tok, "{{") && strings.HasSuffix(tok, "}}"):
+		default:
+			h, err := o.token(tok)
+			if err != nil {
+				return "", err
+			}
+			toks[i] = h
+		}
+	}
+	return strings.Join(toks, "."), nil
+}
+
+func (o *obfuscator) subjects(subjs []string) ([]string, error) {
+	if subjs == nil {
+		return nil, nil
+	}
+	out := make([]string, len(subjs))
+	for i, s := range subjs {
+		h, err := o.subject(s)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = h
+	}
+	return out, nil
+}
+
+func (o *obfuscator) streamName(name string) (string, error) {
+	for _, prefix := range []string{kvStreamPrefix, objStorePrefix} {
+		if rest, ok := strings.CutPrefix(name, prefix); ok && rest != "" {
+			h, err := o.token(rest)
+			return prefix + h, err
+		}
+	}
+	return o.token(name)
+}
+
+func (o *obfuscator) transforms(ts []api.SubjectTransformConfig) ([]api.SubjectTransformConfig, error) {
+	if ts == nil {
+		return nil, nil
+	}
+	out := make([]api.SubjectTransformConfig, len(ts))
+	for i, t := range ts {
+		var err error
+		if out[i].Source, err = o.subject(t.Source); err != nil {
+			return nil, err
+		}
+		if out[i].Destination, err = o.destination(t.Destination); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (o *obfuscator) streamSource(src *api.StreamSource) (*api.StreamSource, error) {
+	if src == nil {
+		return nil, nil
+	}
+	out := *src
+	var err error
+	if out.Name, err = o.streamName(src.Name); err != nil {
+		return nil, err
+	}
+	if out.FilterSubject, err = o.subject(src.FilterSubject); err != nil {
+		return nil, err
+	}
+	if out.SubjectTransforms, err = o.transforms(src.SubjectTransforms); err != nil {
+		return nil, err
+	}
+	if src.External != nil {
+		ext := *src.External
+		if ext.ApiPrefix, err = o.subject(src.External.ApiPrefix); err != nil {
+			return nil, err
+		}
+		if ext.DeliverPrefix, err = o.subject(src.External.DeliverPrefix); err != nil {
+			return nil, err
+		}
+		out.External = &ext
+	}
+	if src.Consumer != nil {
+		c := *src.Consumer
+		if c.Name, err = o.token(src.Consumer.Name); err != nil {
+			return nil, err
+		}
+		if c.DeliverSubject, err = o.subject(src.Consumer.DeliverSubject); err != nil {
+			return nil, err
+		}
+		out.Consumer = &c
+	}
+	return &out, nil
+}
+
+// config rewrites the identifying fields of a stream configuration and
+// drops the descriptive ones; limits and retention stay verbatim
+func (o *obfuscator) config(cfg api.StreamConfig) (api.StreamConfig, error) {
+	out := cfg
+	var err error
+	if out.Name, err = o.streamName(cfg.Name); err != nil {
+		return out, err
+	}
+	if out.Subjects, err = o.subjects(cfg.Subjects); err != nil {
+		return out, err
+	}
+	if out.Mirror, err = o.streamSource(cfg.Mirror); err != nil {
+		return out, err
+	}
+	if cfg.Sources != nil {
+		out.Sources = make([]*api.StreamSource, len(cfg.Sources))
+		for i, src := range cfg.Sources {
+			if out.Sources[i], err = o.streamSource(src); err != nil {
+				return out, err
+			}
+		}
+	}
+	if cfg.SubjectTransform != nil {
+		ts, err := o.transforms([]api.SubjectTransformConfig{*cfg.SubjectTransform})
+		if err != nil {
+			return out, err
+		}
+		out.SubjectTransform = &ts[0]
+	}
+	if cfg.RePublish != nil {
+		rp := *cfg.RePublish
+		if rp.Source, err = o.subject(cfg.RePublish.Source); err != nil {
+			return out, err
+		}
+		if rp.Destination, err = o.destination(cfg.RePublish.Destination); err != nil {
+			return out, err
+		}
+		out.RePublish = &rp
+	}
+	out.Description = ""
+	out.Metadata = nil
+	out.Placement = nil
+	return out, nil
+}
+
+// consumer rewrites a consumer entry through the server's own snapshot type
+// so every field the restore reads is covered; state stays verbatim
+func (o *obfuscator) consumer(name string, data []byte) (string, []byte, error) {
+	var scs server.SnapshotConsumerState
+	if err := json.Unmarshal(data, &scs); err != nil {
+		return "", nil, fmt.Errorf("consumer %q: %w", name, err)
+	}
+	cfg := *scs.ConsumerConfig
+	var err error
+	if cfg.Durable, err = o.token(cfg.Durable); err != nil {
+		return "", nil, err
+	}
+	if cfg.Name, err = o.token(cfg.Name); err != nil {
+		return "", nil, err
+	}
+	if cfg.FilterSubject, err = o.subject(cfg.FilterSubject); err != nil {
+		return "", nil, err
+	}
+	if cfg.FilterSubjects, err = o.subjects(cfg.FilterSubjects); err != nil {
+		return "", nil, err
+	}
+	if cfg.DeliverSubject, err = o.subject(cfg.DeliverSubject); err != nil {
+		return "", nil, err
+	}
+	if cfg.DeliverGroup, err = o.token(cfg.DeliverGroup); err != nil {
+		return "", nil, err
+	}
+	cfg.PriorityGroups = slices.Clone(cfg.PriorityGroups)
+	for i, g := range cfg.PriorityGroups {
+		if cfg.PriorityGroups[i], err = o.token(g); err != nil {
+			return "", nil, err
+		}
+	}
+	cfg.Description = ""
+	cfg.Metadata = nil
+	scs.ConsumerConfig = &cfg
+
+	hashedName, err := o.token(name)
+	if err != nil {
+		return "", nil, err
+	}
+	out, err := json.Marshal(scs)
+	if err != nil {
+		return "", nil, err
+	}
+	return hashedName, out, nil
+}
+
+// message rewrites a message's subject and headers; control headers stay
+// verbatim, subject-valued headers are token hashed and every other value
+// is hashed whole. Headers are written in key order so the output is
+// deterministic. The body is dropped by the caller
+func (o *obfuscator) message(subject string, h nats.Header) (string, []byte, error) {
+	subj, err := o.subject(subject)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(h) == 0 {
+		return subj, nil, nil
+	}
+
+	var out bytes.Buffer
+	out.WriteString("NATS/1.0\r\n")
+	for _, key := range slices.Sorted(maps.Keys(h)) {
+		for _, val := range h[key] {
+			v, err := o.headerValue(key, val)
+			if err != nil {
+				return "", nil, err
+			}
+			out.WriteString(key + ": " + v + "\r\n")
+		}
+	}
+	out.WriteString("\r\n")
+	return subj, out.Bytes(), nil
+}
+
+func (o *obfuscator) headerValue(key, val string) (string, error) {
+	switch {
+	case equalsAny(key, server.KVOperation, server.JSMarkerReason, server.JSMessageTTL, server.JSMsgRollup, server.JSExpectedLastSubjSeq,
+		server.JSSchedulePattern, server.JSScheduleTTL, server.JSScheduleTimeZone):
+		return val, nil
+	case equalsAny(key, server.JSExpectedLastSubjSeqSubj, server.JSScheduleTarget, server.JSScheduleSource):
+		return o.subject(val)
+	default:
+		return o.token(val)
+	}
+}
+
+func equalsAny(key string, names ...string) bool {
+	for _, n := range names {
+		if strings.EqualFold(key, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *obfuscator) keyFileBytes() ([]byte, error) {
+	return json.MarshalIndent(obfuscationKeyFile{
+		Version: keyFileVersion,
+		Secret:  base64.StdEncoding.EncodeToString(o.secret),
+		Map:     o.reverse,
+	}, "", "  ")
+}
+
+// keyFilePath is the sibling of the target that receives the mappings
+func keyFilePath(target string) string {
+	return filepath.Clean(target) + keyFileSuffix
+}
+
+// writeKeyFile refuses to clobber a key file it did not read this run and
+// replaces the file atomically, so the input key file is never left
+// truncated. It reports whether the file is new
+func (o *obfuscator) writeKeyFile(path string, inputKeyFile string) (created bool, err error) {
+	same := false
+	if inputKeyFile != "" {
+		a, errA := filepath.Abs(inputKeyFile)
+		b, errB := filepath.Abs(path)
+		same = errA == nil && errB == nil && a == b
+	}
+	if !same {
+		if _, err := os.Stat(path); err == nil {
+			return false, fmt.Errorf("key file %s already exists", path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+
+	data, err := o.keyFileBytes()
+	if err != nil {
+		return false, err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*")
+	if err != nil {
+		return false, err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return false, err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return false, err
+	}
+	if err := tmp.Close(); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return false, err
+	}
+	return !same, nil
+}

--- a/backup/obfuscate_test.go
+++ b/backup/obfuscate_test.go
@@ -1,0 +1,459 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/s2"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+var tokenRE = regexp.MustCompile(`^[0-9a-v]{16}$`)
+
+func TestObfuscatorTokens(t *testing.T) {
+	o, err := newObfuscator("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	must := func(v string, err error) string {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+
+	a := must(o.token("orders"))
+	if a != must(o.token("orders")) || !tokenRE.MatchString(a) {
+		t.Fatalf("token not stable or malformed: %q", a)
+	}
+	if a == must(o.token("Orders")) || a == must(o.token("orders ")) {
+		t.Fatal("distinct tokens must hash differently")
+	}
+	if must(o.subject("orders.new")) != a+"."+must(o.token("new")) {
+		t.Fatal("subjects must hash token by token")
+	}
+	if must(o.subject("orders.*")) != a+".*" || must(o.subject("orders.>")) != a+".>" {
+		t.Fatal("wildcards must pass through")
+	}
+	if must(o.subject("$KV.bucket.key")) != "$KV."+must(o.token("bucket"))+"."+must(o.token("key")) {
+		t.Fatal("$KV root must pass through")
+	}
+	if must(o.subject("$O.bucket.M.x")) != "$O."+must(o.token("bucket"))+"."+must(o.token("M"))+"."+must(o.token("x")) {
+		t.Fatal("$O root must pass through")
+	}
+	if must(o.destination("dest.{{wildcard(1)}}")) != must(o.token("dest"))+".{{wildcard(1)}}" {
+		t.Fatal("mapping functions must pass through destinations")
+	}
+	if must(o.subject("dest.{{tenant}}")) != must(o.token("dest"))+"."+must(o.token("{{tenant}}")) {
+		t.Fatal("mapping function tokens outside destinations must hash")
+	}
+	if must(o.streamName("KV_bucket")) != "KV_"+must(o.token("bucket")) || must(o.streamName("OBJ_files")) != "OBJ_"+must(o.token("files")) {
+		t.Fatal("bucket prefixes must be preserved")
+	}
+	if must(o.streamName("ORDERS")) != must(o.token("ORDERS")) || must(o.streamName("KV_")) != must(o.token("KV_")) {
+		t.Fatal("plain stream names hash whole")
+	}
+	if must(o.token("")) != "" || must(o.subject("")) != "" {
+		t.Fatal("empty values pass through")
+	}
+
+	other, _ := newObfuscator("")
+	if b, _ := other.token("orders"); a == b {
+		t.Fatal("a fresh secret must produce different hashes")
+	}
+}
+
+func TestObfuscatorKeyFile(t *testing.T) {
+	o, _ := newObfuscator("")
+	o.token("orders")
+	o.token("new")
+	path := filepath.Join(t.TempDir(), "k.json")
+	if created, err := o.writeKeyFile(path, ""); err != nil || !created {
+		t.Fatalf("first write: created %v err %v", created, err)
+	}
+	if st, _ := os.Stat(path); st.Mode().Perm() != 0o600 {
+		t.Fatalf("key file mode %v", st.Mode().Perm())
+	}
+	if _, err := o.writeKeyFile(path, ""); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected refusal to clobber, got %v", err)
+	}
+	if created, err := o.writeKeyFile(path, path); err != nil || created {
+		t.Fatalf("rewriting the input key file must be allowed and not count as new: created %v err %v", created, err)
+	}
+	if entries, _ := os.ReadDir(filepath.Dir(path)); len(entries) != 1 {
+		t.Fatalf("temp file left behind: %v", entries)
+	}
+
+	loaded, err := newObfuscator(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h, _ := loaded.token("orders"); h != o.forward["orders"] {
+		t.Fatal("loaded secret must reproduce hashes")
+	}
+	if !reflect.DeepEqual(loaded.reverse, o.reverse) {
+		t.Fatal("loaded mappings differ")
+	}
+
+	raw, _ := os.ReadFile(path)
+	var kf obfuscationKeyFile
+	json.Unmarshal(raw, &kf)
+	for h := range kf.Map {
+		kf.Map[h] = "tampered"
+	}
+	tampered, _ := json.Marshal(kf)
+	os.WriteFile(path, tampered, 0o600)
+	if _, err := newObfuscator(path); err == nil || !strings.Contains(err.Error(), "does not match the secret") {
+		t.Fatalf("expected a tamper error, got %v", err)
+	}
+
+	os.WriteFile(path, []byte(`{"version":2,"secret":"AA==","map":{}}`), 0o600)
+	if _, err := newObfuscator(path); err == nil || !strings.Contains(err.Error(), "unsupported key file version") {
+		t.Fatalf("expected a version error, got %v", err)
+	}
+}
+
+func TestObfuscatorMessageHeaders(t *testing.T) {
+	o, _ := newObfuscator("")
+	hdr, err := nats.DecodeHeadersMsg([]byte("NATS/1.0\r\nKV-Operation: DEL\r\nNats-Marker-Reason: MaxAge\r\nNats-TTL: 5s\r\nNats-Rollup: sub\r\nNats-Expected-Last-Subject-Sequence: 12\r\nNats-Expected-Last-Subject-Sequence-Subject: orders.new\r\nNats-Schedule: @every 1h\r\nNats-Schedule-Source: inbox.orders\r\nNats-Schedule-TTL: 5m\r\nNats-Schedule-Target: jobs.run\r\nNats-Schedule-Time-Zone: Europe/London\r\nX-Batch: seven\r\nX-Batch: eight\r\n\r\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	subj, out, err := o.message("orders.new", hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSubj, _ := o.subject("orders.new")
+	jobs, _ := o.subject("jobs.run")
+	inbox, _ := o.subject("inbox.orders")
+	seven, _ := o.token("seven")
+	eight, _ := o.token("eight")
+	want := "NATS/1.0\r\nKV-Operation: DEL\r\nNats-Expected-Last-Subject-Sequence: 12\r\nNats-Expected-Last-Subject-Sequence-Subject: " + newSubj + "\r\nNats-Marker-Reason: MaxAge\r\nNats-Rollup: sub\r\nNats-Schedule: @every 1h\r\nNats-Schedule-Source: " + inbox + "\r\nNats-Schedule-TTL: 5m\r\nNats-Schedule-Target: " + jobs + "\r\nNats-Schedule-Time-Zone: Europe/London\r\nNats-TTL: 5s\r\nX-Batch: " + seven + "\r\nX-Batch: " + eight + "\r\n\r\n"
+	if subj != newSubj || string(out) != want {
+		t.Fatalf("got\n%q\nwant\n%q", out, want)
+	}
+	if strings.Contains(string(out), "orders") || strings.Contains(string(out), "seven") {
+		t.Fatal("original values leaked")
+	}
+	if _, err := nats.DecodeHeadersMsg(out); err != nil {
+		t.Fatalf("rewritten block does not decode: %v", err)
+	}
+
+	subj, out, err = o.message("orders.new", nil)
+	if err != nil || subj != newSubj || out != nil {
+		t.Fatalf("headerless message: %q %q %v", subj, out, err)
+	}
+}
+
+func obfuscationFixture(t *testing.T) string {
+	t.Helper()
+	cfg := fixtureConfig()
+	cfg.Description = "secret description"
+	cfg.Metadata = map[string]string{"owner": "alice"}
+	cfg.Placement = &api.Placement{Cluster: "EAST"}
+	cfg.RePublish = &api.RePublish{Source: "orders.*", Destination: "republished.{{wildcard(1)}}"}
+	cfg.Sources = []*api.StreamSource{{Name: "UPSTREAM", FilterSubject: "orders.>", External: &api.ExternalStream{ApiPrefix: "$JS.HUB.API"}}}
+	cfg.MaxMsgs = 1000
+	cfg.MaxAge = 0
+
+	consumer := func(name string) []byte {
+		data, err := json.Marshal(server.SnapshotConsumerState{
+			ConsumerConfig: &server.ConsumerConfig{Durable: name, Name: name, FilterSubject: "orders.new", DeliverSubject: "delivery-inbox.orders", DeliverGroup: "acme-workers", PriorityGroups: []string{"vip-customers"}, Description: "secret consumer", Metadata: map[string]string{"team": "billing"}},
+			ConsumerState:  &server.ConsumerState{Delivered: server.SequencePair{Consumer: 4, Stream: 9}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+	msgs := []testMsg{
+		{"orders.new", 2, 1_000, "", "order one"},
+		{"orders.paid", 3, 2_000, "NATS/1.0\r\nX-Batch: batch-seven\r\n\r\n", "paid one"},
+		{"orders.new", 5, 3_000, "NATS/1.0\r\nKV-Operation: DEL\r\n\r\n", ""},
+		{"orders.shipped", 6, 4_000, "NATS/1.0\r\nNats-Marker-Reason: MaxAge\r\n\r\n", ""},
+		{"orders.new", 9, 5_000, "NATS/1.0\r\nNats-TTL: 1s\r\nNats-Expected-Last-Subject-Sequence-Subject: orders.new\r\n\r\n", "order two"},
+		{"audit.log", 10, 6_000, "", "audit entry"},
+	}
+	st := api.StreamState{Msgs: 6, Bytes: 1, FirstSeq: 2, LastSeq: 14, Consumers: 2}
+	dir := filepath.Join(t.TempDir(), "src")
+	writeBackupDir(t, dir, cfg, st, encodeBackup(t, st, map[string][]byte{"consumer-one": consumer("consumer-one"), "consumer-two": consumer("consumer-two")}, msgs, true))
+	return dir
+}
+
+func decompressed(t *testing.T, path string) []byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(s2.NewReader(f))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func loadKeyFile(t *testing.T, path string) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kf obfuscationKeyFile
+	if err := json.Unmarshal(raw, &kf); err != nil {
+		t.Fatal(err)
+	}
+	return kf.Map
+}
+
+func TestEditObfuscate(t *testing.T) {
+	src := obfuscationFixture(t)
+	dst, res := edit(t, src, Obfuscate())
+	if _, err := Verify(dst); err != nil {
+		t.Fatalf("output does not verify: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dst)
+	if len(entries) != 2 {
+		t.Fatalf("target must hold only the backup files: %v", entries)
+	}
+	keyFile := dst + keyFileSuffix
+	if res.Report.Obfuscation == nil || res.Report.Obfuscation.KeyFile != keyFile {
+		t.Fatalf("unexpected obfuscation report %+v", res.Report.Obfuscation)
+	}
+	if st, err := os.Stat(keyFile); err != nil || st.Mode().Perm() != 0o600 {
+		t.Fatalf("key file missing or wrong mode: %v", err)
+	}
+
+	archive := string(decompressed(t, filepath.Join(dst, DataFile)))
+	metaRaw, _ := os.ReadFile(filepath.Join(dst, MetaFile))
+	for _, leak := range []string{"orders", "audit", "ORDERS", "UPSTREAM", "consumer-one", "consumer-two", "batch-seven", "order one", "paid one", "delivery-inbox", "republished", "HUB", "secret", "alice", "billing", "EAST", "acme-workers", "vip-customers"} {
+		if strings.Contains(archive, leak) {
+			t.Fatalf("archive leaks %q", leak)
+		}
+		if strings.Contains(string(metaRaw), leak) {
+			t.Fatalf("meta file leaks %q", leak)
+		}
+	}
+	for _, keep := range []string{"X-Batch: ", "KV-Operation: DEL", "Nats-Marker-Reason: MaxAge", "Nats-TTL: 1s"} {
+		if !strings.Contains(archive, keep) {
+			t.Fatalf("archive lost %q", keep)
+		}
+	}
+
+	items := readItems(t, dst)
+	msgs := messagesOf(items)
+	if len(msgs) != 6 {
+		t.Fatalf("expected 6 messages, got %d", len(msgs))
+	}
+	var bytesWritten uint64
+	for _, m := range msgs {
+		if m.PayloadSize != 0 || !tokenRE.MatchString(strings.Split(m.Subject, ".")[0]) {
+			t.Fatalf("body kept or subject not hashed: %+v", m)
+		}
+		bytesWritten += storedMsgSize(len(m.Subject), m.HdrSize, m.PayloadSize)
+	}
+	if res.Report.Obfuscation.BodiesDropped != 4 || res.State.Bytes != bytesWritten || res.State.Msgs != 6 {
+		t.Fatalf("unexpected accounting: report %+v state %+v written %d", res.Report.Obfuscation, res.State, bytesWritten)
+	}
+	if st := items[0].(*State).State; st.Bytes != 0 || st.Consumers != 2 {
+		t.Fatalf("archive state must carry advisory bytes: %+v", st)
+	}
+
+	mapping := loadKeyFile(t, keyFile)
+	originals := map[string]string{}
+	for h, orig := range mapping {
+		originals[orig] = h
+	}
+	for _, want := range []string{"orders", "new", "paid", "shipped", "audit", "log", "ORDERS", "UPSTREAM", "consumer-one", "consumer-two", "batch-seven", "delivery-inbox", "republished", "$JS", "HUB", "API", "acme-workers", "vip-customers"} {
+		if _, ok := originals[want]; !ok {
+			t.Fatalf("key file lacks a mapping for %q", want)
+		}
+	}
+	if res.Report.Obfuscation.TokensMapped != len(mapping) {
+		t.Fatalf("tokens mapped %d vs key file %d", res.Report.Obfuscation.TokensMapped, len(mapping))
+	}
+
+	sc := loadMetaFile(t, dst)
+	cfg := sc.Config
+	if cfg.Name != originals["ORDERS"] || !reflect.DeepEqual(cfg.Subjects, []string{originals["orders"] + ".>", originals["audit"] + ".*"}) {
+		t.Fatalf("config identity not hashed: %+v", cfg)
+	}
+	if cfg.Description != "" || cfg.Metadata != nil || cfg.Placement != nil || cfg.MaxMsgs != 1000 {
+		t.Fatalf("descriptive fields must be dropped and limits kept: %+v", cfg)
+	}
+	if cfg.RePublish.Source != originals["orders"]+".*" || cfg.RePublish.Destination != originals["republished"]+".{{wildcard(1)}}" {
+		t.Fatalf("republish not hashed: %+v", cfg.RePublish)
+	}
+	if cfg.Sources[0].Name != originals["UPSTREAM"] || cfg.Sources[0].External.ApiPrefix != originals["$JS"]+"."+originals["HUB"]+"."+originals["API"] {
+		t.Fatalf("source not hashed: %+v", cfg.Sources[0])
+	}
+	if !sc.Edit.Obfuscated || !reflect.DeepEqual(sc.Edit.Options, []string{"obfuscate"}) {
+		t.Fatalf("unexpected edit block %+v", sc.Edit)
+	}
+
+	consumers := consumersOf(items)
+	for i, orig := range []string{"consumer-one", "consumer-two"} {
+		c := consumers[i]
+		var scs server.SnapshotConsumerState
+		if err := json.Unmarshal(c.Data, &scs); err != nil {
+			t.Fatal(err)
+		}
+		if c.Name != originals[orig] || scs.Durable != originals[orig] || scs.ConsumerConfig.Name != originals[orig] {
+			t.Fatalf("consumer identity not hashed consistently: %s %+v", c.Name, scs.ConsumerConfig)
+		}
+		if scs.FilterSubject != originals["orders"]+"."+originals["new"] || scs.DeliverSubject != originals["delivery-inbox"]+"."+originals["orders"] {
+			t.Fatalf("consumer subjects not hashed: %+v", scs.ConsumerConfig)
+		}
+		if scs.DeliverGroup != originals["acme-workers"] || !reflect.DeepEqual(scs.PriorityGroups, []string{originals["vip-customers"]}) {
+			t.Fatalf("consumer groups not hashed: %+v", scs.ConsumerConfig)
+		}
+		if scs.Description != "" || scs.Metadata != nil || scs.Delivered.Stream != 9 {
+			t.Fatalf("consumer description/metadata must be dropped, state kept: %+v", scs)
+		}
+		if !server.SubjectsCollide(scs.FilterSubject, cfg.Subjects[0]) {
+			t.Fatalf("hashed filter %q no longer within hashed subject %q", scs.FilterSubject, cfg.Subjects[0])
+		}
+	}
+
+	seq9 := msgs[4]
+	body, _ := io.ReadAll(seq9.Body)
+	if !strings.Contains(string(body), "Nats-Expected-Last-Subject-Sequence-Subject: "+originals["orders"]+"."+originals["new"]) {
+		t.Fatalf("subject-valued header not token hashed: %q", body)
+	}
+	seq3 := msgs[1]
+	body, _ = io.ReadAll(seq3.Body)
+	if !strings.Contains(string(body), "X-Batch: "+originals["batch-seven"]) {
+		t.Fatalf("header value not hashed through the table: %q", body)
+	}
+}
+
+func TestEditObfuscateDeterminism(t *testing.T) {
+	src := obfuscationFixture(t)
+	first, _ := edit(t, src, Obfuscate())
+	second, _ := edit(t, src, Obfuscate(), ObfuscationKeyFile(first+keyFileSuffix))
+	third, _ := edit(t, src, Obfuscate())
+
+	for _, name := range []string{DataFile, MetaFile} {
+		a, _ := os.ReadFile(filepath.Join(first, name))
+		b, _ := os.ReadFile(filepath.Join(second, name))
+		c, _ := os.ReadFile(filepath.Join(third, name))
+		if !bytes.Equal(a, b) {
+			t.Fatalf("%s differs under the same key file", name)
+		}
+		if bytes.Equal(a, c) {
+			t.Fatalf("%s identical under a fresh secret", name)
+		}
+	}
+	if !reflect.DeepEqual(loadKeyFile(t, first+keyFileSuffix), loadKeyFile(t, second+keyFileSuffix)) {
+		t.Fatal("key files differ under the same secret")
+	}
+}
+
+func TestEditObfuscateDryRunAndRefusals(t *testing.T) {
+	src := obfuscationFixture(t)
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "dst")
+
+	dry, err := Edit(context.Background(), src, dst, Obfuscate(), DryRun())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entries, _ := os.ReadDir(parent); len(entries) != 0 {
+		t.Fatalf("dry run wrote files: %v", entries)
+	}
+	if dry.Report.Obfuscation == nil || dry.Report.Obfuscation.KeyFile != "" || dry.Report.Obfuscation.BodiesDropped != 4 || dry.State.Bytes == 0 {
+		t.Fatalf("unexpected dry run result %+v %+v", dry.Report.Obfuscation, dry.State)
+	}
+
+	os.WriteFile(dst+keyFileSuffix, []byte("{}"), 0o600)
+	_, err = Edit(context.Background(), src, dst, Obfuscate())
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected refusal to clobber a key file, got %v", err)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		t.Fatal("target must not exist after a refused edit")
+	}
+}
+
+func TestEditObfuscateKVChain(t *testing.T) {
+	src := kvDir(t, kvConfig())
+	obf, res := edit(t, src, Obfuscate())
+	if !strings.HasPrefix(res.Config.Name, "KV_") || res.Config.Subjects[0] != "$KV."+strings.TrimPrefix(res.Config.Name, "KV_")+".>" {
+		t.Fatalf("bucket relation lost: %+v", res.Config)
+	}
+
+	dst, res := edit(t, obf, KVCompact())
+	if res.Report.Kept != 2 || res.Report.Dropped.KVCompact != 7 {
+		t.Fatalf("compaction of the obfuscated bucket differs: %+v", res.Report)
+	}
+	if _, err := Verify(dst); err != nil {
+		t.Fatal(err)
+	}
+
+	src = kvDir(t, kvConfig())
+	_, res = edit(t, src, Obfuscate(), KVCompact(), Renumber())
+	if res.Report.Kept != 2 || res.State.Bytes == 0 || res.State.FirstSeq != 1 || res.State.LastSeq != 2 {
+		t.Fatalf("obfuscated two-pass renumber: %+v %+v", res.Report, res.State)
+	}
+}
+
+func TestEditObfuscateFailedCommitKeepsInputKeyFile(t *testing.T) {
+	src := kvDir(t, kvConfig())
+	first, _ := edit(t, src, Obfuscate())
+	keyFile := first + keyFileSuffix
+	before := loadKeyFile(t, keyFile)
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "dst")
+	block := func() {
+		if err := os.WriteFile(dst, []byte("in the way"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := Edit(context.Background(), src, dst, Obfuscate(), KVCompact(), ObfuscationKeyFile(keyFile), betweenPasses(block))
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) || linkErr.Op != "rename" {
+		t.Fatalf("expected the commit rename to fail, got %v", err)
+	}
+	after := loadKeyFile(t, keyFile)
+	for h, orig := range before {
+		if after[h] != orig {
+			t.Fatalf("input key file lost mapping %q", h)
+		}
+	}
+	if _, err := newObfuscator(keyFile); err != nil {
+		t.Fatalf("input key file no longer loads: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(parent, "dst"+keyFileSuffix)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("a key file was left beside the failed target: %v", err)
+	}
+}

--- a/backup/options.go
+++ b/backup/options.go
@@ -1,0 +1,296 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+)
+
+// EditOption configures Edit; options are validated when Edit runs
+type EditOption func(*editOptions)
+
+type headerMatch struct {
+	name  string
+	value string
+}
+
+type editOptions struct {
+	subjects            []string
+	excludeSubjects     []string
+	after               time.Time
+	before              time.Time
+	hasAfter            bool
+	hasBefore           bool
+	firstSeq            uint64
+	lastSeq             uint64
+	hasFirstSeq         bool
+	hasLastSeq          bool
+	headerPresent       []string
+	headerValues        []headerMatch
+	noHeader            []string
+	payloadMatch        []*regexp.Regexp
+	excludePayloadMatch []*regexp.Regexp
+	lastPerSubject      int
+	hasLastPerSubject   bool
+	kvCompact           bool
+	renumber            bool
+	obfuscate           bool
+	keyFile             string
+	dryRun              bool
+	toolVersion         string
+	betweenPasses       func()
+}
+
+// Subjects keeps messages whose subject matches at least one of the given NATS subject patterns
+func Subjects(subjects ...string) EditOption {
+	return func(o *editOptions) { o.subjects = append(o.subjects, subjects...) }
+}
+
+// ExcludeSubjects drops messages whose subject matches any of the given NATS subject patterns
+func ExcludeSubjects(subjects ...string) EditOption {
+	return func(o *editOptions) { o.excludeSubjects = append(o.excludeSubjects, subjects...) }
+}
+
+// After keeps messages whose timestamp is at or after t
+func After(t time.Time) EditOption {
+	return func(o *editOptions) { o.after, o.hasAfter = t, true }
+}
+
+// Before keeps messages whose timestamp is before t
+func Before(t time.Time) EditOption {
+	return func(o *editOptions) { o.before, o.hasBefore = t, true }
+}
+
+// FirstSeq keeps messages with a sequence at or above seq
+func FirstSeq(seq uint64) EditOption {
+	return func(o *editOptions) { o.firstSeq, o.hasFirstSeq = seq, true }
+}
+
+// LastSeq keeps messages with a sequence at or below seq
+func LastSeq(seq uint64) EditOption {
+	return func(o *editOptions) { o.lastSeq, o.hasLastSeq = seq, true }
+}
+
+// HeaderPresent keeps messages carrying the named header with at least one value
+func HeaderPresent(name string) EditOption {
+	return func(o *editOptions) { o.headerPresent = append(o.headerPresent, name) }
+}
+
+// HeaderValue keeps messages where any value of the named header equals value exactly
+func HeaderValue(name string, value string) EditOption {
+	return func(o *editOptions) { o.headerValues = append(o.headerValues, headerMatch{name: name, value: value}) }
+}
+
+// NoHeader drops messages carrying the named header
+func NoHeader(name string) EditOption {
+	return func(o *editOptions) { o.noHeader = append(o.noHeader, name) }
+}
+
+// PayloadMatch keeps messages whose payload matches at least one of the given expressions
+func PayloadMatch(re *regexp.Regexp) EditOption {
+	return func(o *editOptions) { o.payloadMatch = append(o.payloadMatch, re) }
+}
+
+// ExcludePayloadMatch drops messages whose payload matches any of the given expressions
+func ExcludePayloadMatch(re *regexp.Regexp) EditOption {
+	return func(o *editOptions) { o.excludePayloadMatch = append(o.excludePayloadMatch, re) }
+}
+
+// LastPerSubject keeps only the newest n messages of every subject in the filtered result
+func LastPerSubject(n int) EditOption {
+	return func(o *editOptions) { o.lastPerSubject, o.hasLastPerSubject = n, true }
+}
+
+// KVCompact reduces a KV bucket backup to the latest revision of every key,
+// dropping keys whose latest revision is a delete or purge marker. It is
+// applied to the filtered result and requires a KV bucket backup
+func KVCompact() EditOption {
+	return func(o *editOptions) { o.kvCompact = true }
+}
+
+// Renumber numbers the kept messages 1..K and drops all consumers
+func Renumber() EditOption {
+	return func(o *editOptions) { o.renumber = true }
+}
+
+// Obfuscate replaces identifying names and subjects with keyed hashes and
+// drops message bodies, writing the reverse mapping to a key file beside the target
+func Obfuscate() EditOption {
+	return func(o *editOptions) { o.obfuscate = true }
+}
+
+// ObfuscationKeyFile reuses the secret and mappings from an earlier key file so
+// several backups obfuscate consistently
+func ObfuscationKeyFile(path string) EditOption {
+	return func(o *editOptions) { o.keyFile = path }
+}
+
+// betweenPasses runs after the first pass of a two-pass edit; tests use it
+// to alter the source underneath the held handle
+func betweenPasses(fn func()) EditOption {
+	return func(o *editOptions) { o.betweenPasses = fn }
+}
+
+// DryRun computes the Result without writing anything
+func DryRun() EditOption {
+	return func(o *editOptions) { o.dryRun = true }
+}
+
+// ToolVersion records the calling tool's version in the meta file's edit
+// block; without it the edit block carries no version
+func ToolVersion(v string) EditOption {
+	return func(o *editOptions) { o.toolVersion = v }
+}
+
+func (o *editOptions) validate() error {
+	for _, s := range slices.Concat(o.subjects, o.excludeSubjects) {
+		if !server.IsValidSubject(s) {
+			return fmt.Errorf("invalid subject filter %q", s)
+		}
+	}
+	nanoMin, nanoMax := time.Unix(0, math.MinInt64), time.Unix(0, math.MaxInt64)
+	for _, tc := range []struct {
+		set  bool
+		name string
+		t    time.Time
+	}{{o.hasAfter, "After", o.after}, {o.hasBefore, "Before", o.before}} {
+		if tc.set && (tc.t.Before(nanoMin) || tc.t.After(nanoMax)) {
+			return fmt.Errorf("%s %s is outside the supported time range", tc.name, tc.t.Format(time.RFC3339))
+		}
+	}
+	if o.hasAfter && o.hasBefore && !o.after.Before(o.before) {
+		return errors.New("After must be earlier than Before")
+	}
+	if o.hasFirstSeq && o.hasLastSeq && o.firstSeq > o.lastSeq {
+		return fmt.Errorf("FirstSeq %d is above LastSeq %d", o.firstSeq, o.lastSeq)
+	}
+	for _, name := range slices.Concat(o.headerPresent, o.noHeader) {
+		if err := validateHeaderName(name); err != nil {
+			return err
+		}
+	}
+	for _, hm := range o.headerValues {
+		if err := validateHeaderName(hm.name); err != nil {
+			return err
+		}
+		if strings.ContainsAny(hm.value, "\r\n") {
+			return fmt.Errorf("invalid header value %q", hm.value)
+		}
+	}
+	for _, re := range slices.Concat(o.payloadMatch, o.excludePayloadMatch) {
+		if re == nil {
+			return errors.New("payload expression is nil")
+		}
+	}
+	if o.hasLastPerSubject && o.lastPerSubject < 1 {
+		return fmt.Errorf("LastPerSubject requires at least 1, got %d", o.lastPerSubject)
+	}
+	if o.kvCompact && o.lastPerSubject > 0 {
+		return errors.New("KVCompact and LastPerSubject are mutually exclusive")
+	}
+	if o.keyFile != "" && !o.obfuscate {
+		return errors.New("ObfuscationKeyFile requires Obfuscate")
+	}
+
+	return nil
+}
+
+func validateHeaderName(name string) error {
+	if name == "" || strings.ContainsAny(name, ": \t\r\n") {
+		return fmt.Errorf("invalid header name %q", name)
+	}
+	return nil
+}
+
+func (o *editOptions) perSubject() bool {
+	return o.lastPerSubject > 0 || o.kvCompact
+}
+
+func (o *editOptions) hasHeaderFilters() bool {
+	return len(o.headerPresent)+len(o.headerValues)+len(o.noHeader) > 0
+}
+
+func (o *editOptions) hasPayloadFilters() bool {
+	return len(o.payloadMatch)+len(o.excludePayloadMatch) > 0
+}
+
+// canonical renders the options in a fixed order so equal option sets produce equal meta files
+func (o *editOptions) canonical() []string {
+	var out []string
+	add := func(key string, values []string) {
+		values = slices.Clone(values)
+		slices.Sort(values)
+		for _, v := range values {
+			out = append(out, key+"="+v)
+		}
+	}
+
+	add("subject", o.subjects)
+	add("exclude-subject", o.excludeSubjects)
+	if o.hasAfter {
+		out = append(out, "after="+o.after.UTC().Format(time.RFC3339Nano))
+	}
+	if o.hasBefore {
+		out = append(out, "before="+o.before.UTC().Format(time.RFC3339Nano))
+	}
+	if o.hasFirstSeq {
+		out = append(out, "first-seq="+strconv.FormatUint(o.firstSeq, 10))
+	}
+	if o.hasLastSeq {
+		out = append(out, "last-seq="+strconv.FormatUint(o.lastSeq, 10))
+	}
+	add("header", o.headerPresent)
+	hv := make([]string, 0, len(o.headerValues))
+	for _, hm := range o.headerValues {
+		hv = append(hv, hm.name+":"+hm.value)
+	}
+	add("header", hv)
+	add("no-header", o.noHeader)
+	add("payload-match", regexStrings(o.payloadMatch))
+	add("exclude-payload-match", regexStrings(o.excludePayloadMatch))
+	if o.lastPerSubject > 0 {
+		out = append(out, "last-per-subject="+strconv.Itoa(o.lastPerSubject))
+	}
+	if o.kvCompact {
+		out = append(out, "kv-compact")
+	}
+	if o.renumber {
+		out = append(out, "renumber")
+	}
+	if o.obfuscate {
+		out = append(out, "obfuscate")
+	}
+	if out == nil {
+		out = []string{}
+	}
+
+	return out
+}
+
+func regexStrings(res []*regexp.Regexp) []string {
+	out := make([]string, 0, len(res))
+	for _, re := range res {
+		out = append(out, re.String())
+	}
+	return out
+}

--- a/backup/source.go
+++ b/backup/source.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nats-io/jsm.go"
+)
+
+const (
+	kvStreamPrefix  = "KV_"
+	kvSubjectPrefix = "$KV."
+)
+
+// source is a backup directory opened for editing; the archive handle is held
+// for the whole edit so a second pass reads exactly what the first observed
+type source struct {
+	dataPath string
+	metaFile *metaFile
+	f        *os.File
+	stat     os.FileInfo
+	digest   hash.Hash
+	tee      io.Reader
+}
+
+func openSource(dir string) (*source, error) {
+	data, meta, err := backupPaths(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	mf, err := readMetaFile(meta)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(data)
+	if err != nil {
+		return nil, err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	src := &source{dataPath: data, metaFile: mf, f: f, stat: stat, digest: sha256.New()}
+	src.tee = io.TeeReader(f, src.digest)
+
+	return src, nil
+}
+
+func (s *source) close() error {
+	return s.f.Close()
+}
+
+// finishDigest hashes whatever the decoder left unread so the digest covers the whole file
+func (s *source) finishDigest() (string, error) {
+	if _, err := io.Copy(io.Discard, s.tee); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(s.digest.Sum(nil)), nil
+}
+
+// rewind positions the held handle at the start for a second pass after
+// checking the file was not modified in place since it was opened
+func (s *source) rewind() (io.Reader, error) {
+	now, err := s.f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if now.Size() != s.stat.Size() || !now.ModTime().Equal(s.stat.ModTime()) {
+		return nil, fmt.Errorf("%s changed during the edit (size %d -> %d, modified %s -> %s)", s.dataPath, s.stat.Size(), now.Size(), s.stat.ModTime().Format("15:04:05.000"), now.ModTime().Format("15:04:05.000"))
+	}
+	if _, err := s.f.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return s.f, nil
+}
+
+func (s *source) isKVBucket() bool {
+	cfg := s.metaFile.Config
+	if !jsm.IsKVBucketStream(cfg.Name) {
+		return false
+	}
+	bucket := strings.TrimPrefix(cfg.Name, kvStreamPrefix)
+	return bucket != "" && len(cfg.Subjects) == 1 && cfg.Subjects[0] == kvSubjectPrefix+bucket+".>"
+}
+
+// target is the output directory, built in a sibling staging directory and
+// moved into place with one rename once the sentinel and meta file are on disk
+type target struct {
+	final   string
+	staging string
+	existed bool
+}
+
+func prepareTarget(dir string) (*target, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &target{final: abs}
+	st, err := os.Stat(abs)
+	switch {
+	case err == nil:
+		if !st.IsDir() {
+			return nil, fmt.Errorf("target %s exists and is not a directory", abs)
+		}
+		entries, err := os.ReadDir(abs)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) > 0 {
+			return nil, fmt.Errorf("target directory %s is not empty", abs)
+		}
+		t.existed = true
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, err
+	}
+
+	t.staging, err = os.MkdirTemp(filepath.Dir(abs), "."+filepath.Base(abs)+".editing-")
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+func (t *target) path(name string) string {
+	return filepath.Join(t.staging, name)
+}
+
+func (t *target) writeFile(name string, data []byte) error {
+	f, err := os.OpenFile(t.path(name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// commit renames the staging directory onto the target; renaming over an
+// existing empty directory is atomic where the platform allows it, otherwise
+// the target is removed first
+func (t *target) commit() error {
+	d, err := os.Open(t.staging)
+	if err != nil {
+		return err
+	}
+	if err := d.Sync(); err != nil {
+		d.Close()
+		return err
+	}
+	d.Close()
+
+	if err := os.Rename(t.staging, t.final); err == nil || !t.existed {
+		return err
+	}
+	if err := os.Remove(t.final); err != nil {
+		return err
+	}
+	return os.Rename(t.staging, t.final)
+}
+
+func (t *target) discard() {
+	os.RemoveAll(t.staging)
+}

--- a/backup/subjectstate.go
+++ b/backup/subjectstate.go
@@ -1,0 +1,148 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import "unsafe"
+
+// subjectState decides which messages of the filtered result survive a
+// per-subject edit. Messages are observed in ascending sequence order; after
+// Resolve, Keeps answers for any observed message. Nothing outside this file
+// knows how the state is held
+type subjectState interface {
+	Observe(subject string, seq uint64, size uint64, tomb bool)
+	Resolve() resolved
+	Keeps(subject string, seq uint64) bool
+	Stats() (keys uint64, bytes uint64)
+}
+
+// resolved is what a per-subject edit will write: exact message and byte
+// totals and the lowest surviving sequence
+type resolved struct {
+	msgs     uint64
+	bytes    uint64
+	firstSeq uint64
+}
+
+func (r *resolved) add(seq, size uint64) {
+	r.msgs++
+	r.bytes += size
+	if r.firstSeq == 0 || seq < r.firstSeq {
+		r.firstSeq = seq
+	}
+}
+
+func newSubjectState(o *editOptions) subjectState {
+	if o.kvCompact {
+		return &kvCompactState{slots: map[string]kvSlot{}}
+	}
+	return &lastPerSubjectState{n: o.lastPerSubject, rings: map[string]ring{}}
+}
+
+// kvCompactState keeps the latest revision per key and drops keys whose
+// latest revision is a tombstone
+type kvCompactState struct {
+	slots map[string]kvSlot
+	keyB  uint64
+}
+
+type kvSlot struct {
+	seq  uint64
+	size uint64
+	tomb bool
+}
+
+func (s *kvCompactState) Observe(subject string, seq uint64, size uint64, tomb bool) {
+	if _, seen := s.slots[subject]; !seen {
+		s.keyB += uint64(len(subject))
+	}
+	s.slots[subject] = kvSlot{seq: seq, size: size, tomb: tomb}
+}
+
+func (s *kvCompactState) Resolve() resolved {
+	var res resolved
+	for _, slot := range s.slots {
+		if !slot.tomb {
+			res.add(slot.seq, slot.size)
+		}
+	}
+	return res
+}
+
+func (s *kvCompactState) Keeps(subject string, seq uint64) bool {
+	slot, ok := s.slots[subject]
+	return ok && !slot.tomb && slot.seq == seq
+}
+
+func (s *kvCompactState) Stats() (uint64, uint64) {
+	return uint64(len(s.slots)), s.keyB + uint64(len(s.slots))*uint64(unsafe.Sizeof(kvSlot{}))
+}
+
+// lastPerSubjectState keeps the newest n messages of every subject in a
+// ring per subject; sequences arrive ascending, so once a ring is full the
+// cursor always points at its oldest entry
+type lastPerSubjectState struct {
+	n     int
+	rings map[string]ring
+	keyB  uint64
+	slots uint64
+}
+
+type ring struct {
+	entries []ringEntry
+	next    int
+}
+
+type ringEntry struct {
+	seq  uint64
+	size uint64
+}
+
+func (s *lastPerSubjectState) Observe(subject string, seq uint64, size uint64, _ bool) {
+	r, seen := s.rings[subject]
+	if !seen {
+		s.keyB += uint64(len(subject))
+	}
+	e := ringEntry{seq: seq, size: size}
+	if len(r.entries) < s.n {
+		r.entries = append(r.entries, e)
+		s.slots++
+	} else {
+		r.entries[r.next] = e
+		r.next = (r.next + 1) % s.n
+	}
+	s.rings[subject] = r
+}
+
+func (s *lastPerSubjectState) Resolve() resolved {
+	var res resolved
+	for _, r := range s.rings {
+		for _, e := range r.entries {
+			res.add(e.seq, e.size)
+		}
+	}
+	return res
+}
+
+func (s *lastPerSubjectState) Keeps(subject string, seq uint64) bool {
+	for _, e := range s.rings[subject].entries {
+		if e.seq == seq {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *lastPerSubjectState) Stats() (uint64, uint64) {
+	return uint64(len(s.rings)), s.keyB + s.slots*uint64(unsafe.Sizeof(ringEntry{}))
+}

--- a/backup/twopass_test.go
+++ b/backup/twopass_test.go
@@ -1,0 +1,272 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+func TestSubjectStateLastPerSubject(t *testing.T) {
+	s := newSubjectState(&editOptions{lastPerSubject: 2})
+	s.Observe("a", 1, 10, false)
+	s.Observe("b", 2, 20, false)
+	s.Observe("a", 3, 30, true)
+	s.Observe("a", 4, 40, false)
+	s.Observe("c", 5, 50, false)
+
+	res := s.Resolve()
+	if res.msgs != 4 || res.bytes != 140 || res.firstSeq != 2 {
+		t.Fatalf("unexpected resolution %+v", res)
+	}
+	for seq, want := range map[uint64]bool{1: false, 3: true, 4: true} {
+		if s.Keeps("a", seq) != want {
+			t.Fatalf("Keeps(a, %d) = %v", seq, !want)
+		}
+	}
+	if !s.Keeps("b", 2) || !s.Keeps("c", 5) || s.Keeps("d", 5) || s.Keeps("c", 6) {
+		t.Fatal("unexpected Keeps answers")
+	}
+	keys, size := s.Stats()
+	if keys != 3 || size != 3+4*16 {
+		t.Fatalf("unexpected stats %d %d", keys, size)
+	}
+}
+
+func TestSubjectStateKVCompact(t *testing.T) {
+	s := newSubjectState(&editOptions{kvCompact: true})
+	s.Observe("a", 1, 10, false)
+	s.Observe("a", 2, 20, false)
+	s.Observe("b", 3, 30, false)
+	s.Observe("b", 4, 40, true)
+	s.Observe("c", 5, 50, true)
+	s.Observe("c", 6, 60, false)
+
+	res := s.Resolve()
+	if res.msgs != 2 || res.bytes != 80 || res.firstSeq != 2 {
+		t.Fatalf("unexpected resolution %+v", res)
+	}
+	for _, tc := range []struct {
+		subject string
+		seq     uint64
+		want    bool
+	}{{"a", 1, false}, {"a", 2, true}, {"b", 3, false}, {"b", 4, false}, {"c", 5, false}, {"c", 6, true}, {"d", 6, false}} {
+		if s.Keeps(tc.subject, tc.seq) != tc.want {
+			t.Fatalf("Keeps(%s, %d) = %v", tc.subject, tc.seq, !tc.want)
+		}
+	}
+	keys, size := s.Stats()
+	if keys != 3 || size != 3+3*24 {
+		t.Fatalf("unexpected stats %d %d", keys, size)
+	}
+}
+
+func TestEditLastPerSubject(t *testing.T) {
+	sizeOf := func(seqs ...uint64) uint64 {
+		var total uint64
+		for _, m := range fixtureMsgs {
+			for _, seq := range seqs {
+				if m.seq == seq {
+					total += storedMsgSize(len(m.subject), int64(len(m.hdr)), int64(len(m.body)))
+				}
+			}
+		}
+		return total
+	}
+	cases := map[string]struct {
+		opts    []EditOption
+		seqs    []uint64
+		dropped DropCounts
+		state   api.StreamState
+	}{
+		"last 1": {[]EditOption{LastPerSubject(1)}, []uint64{6, 9, 10, 12}, DropCounts{LastPerSubject: 3},
+			api.StreamState{Msgs: 4, Bytes: sizeOf(6, 9, 10, 12), FirstSeq: 2, LastSeq: 14, Consumers: 2}},
+		"last 2": {[]EditOption{LastPerSubject(2)}, []uint64{3, 5, 6, 9, 10, 12}, DropCounts{LastPerSubject: 1},
+			api.StreamState{Msgs: 6, Bytes: sizeOf(3, 5, 6, 9, 10, 12), FirstSeq: 2, LastSeq: 14, Consumers: 2}},
+		"last 1 with filters": {[]EditOption{LastPerSubject(1), Subjects("orders.>"), NoHeader("Nats-TTL")}, []uint64{5, 6, 12}, DropCounts{Subject: 1, Header: 1, LastPerSubject: 2},
+			api.StreamState{Msgs: 3, Bytes: sizeOf(5, 6, 12), FirstSeq: 2, LastSeq: 14, Consumers: 2}},
+		"last 1 renumber": {[]EditOption{LastPerSubject(1), Renumber()}, []uint64{1, 2, 3, 4}, DropCounts{LastPerSubject: 3},
+			api.StreamState{Msgs: 4, Bytes: sizeOf(6, 9, 10, 12), FirstSeq: 1, LastSeq: 4}},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := fixtureDir(t, fixtureConfig(), fixtureMsgs)
+			dst, res := edit(t, src, tc.opts...)
+			if _, err := Verify(dst); err != nil {
+				t.Fatalf("output does not verify: %v", err)
+			}
+			items := readItems(t, dst)
+			if got := seqsOf(messagesOf(items)); !reflect.DeepEqual(got, tc.seqs) {
+				t.Fatalf("kept %v, want %v", got, tc.seqs)
+			}
+			if st := items[0].(*State).State; !reflect.DeepEqual(st, tc.state) {
+				t.Fatalf("archive state %+v, want exact %+v", st, tc.state)
+			}
+			if res.Report.Dropped != tc.dropped || res.Report.Kept != uint64(len(tc.seqs)) {
+				t.Fatalf("report %+v, want dropped %+v", res.Report, tc.dropped)
+			}
+			if res.Report.SubjectStateKeys == 0 || res.Report.SubjectStateBytes == 0 {
+				t.Fatalf("subject state not reported: %+v", res.Report)
+			}
+			if res.State.Msgs != tc.state.Msgs || res.State.Bytes != tc.state.Bytes {
+				t.Fatalf("meta file state %+v", res.State)
+			}
+		})
+	}
+}
+
+var kvMsgs = []testMsg{
+	{"$KV.orders.a", 1, 100, "", "a1"},
+	{"$KV.orders.b", 2, 200, "", "b1"},
+	{"$KV.orders.a", 3, 300, "", "a2"},
+	{"$KV.orders.b", 4, 400, "NATS/1.0\r\nKV-Operation: DEL\r\n\r\n", ""},
+	{"$KV.orders.c", 5, 500, "", "c1"},
+	{"$KV.orders.c", 6, 600, "NATS/1.0\r\nNats-Marker-Reason: MaxAge\r\n\r\n", ""},
+	{"$KV.orders.d", 7, 700, "", "d1"},
+	{"$KV.orders.d", 8, 800, "NATS/1.0\r\nKV-Operation: FOO\r\nNats-Marker-Reason: Remove\r\n\r\n", "d2"},
+	{"$KV.orders.e", 9, 900, "NATS/1.0\r\nKV-Operation: PURGE\r\n\r\n", ""},
+}
+
+func kvConfig() api.StreamConfig {
+	return api.StreamConfig{Name: "KV_orders", Subjects: []string{"$KV.orders.>"}, Storage: api.FileStorage, MaxMsgsPer: 5}
+}
+
+func kvDir(t *testing.T, cfg api.StreamConfig) string {
+	t.Helper()
+	return fixtureDirWithState(t, cfg, api.StreamState{Msgs: 9, Bytes: 999, FirstSeq: 1, LastSeq: 9, Consumers: 2}, kvMsgs)
+}
+
+func TestEditKVCompact(t *testing.T) {
+	cases := map[string]struct {
+		opts    []EditOption
+		seqs    []uint64
+		dropped DropCounts
+		tombs   uint64
+		keys    uint64
+	}{
+		"compact":               {[]EditOption{KVCompact()}, []uint64{3, 8}, DropCounts{KVCompact: 7}, 0, 5},
+		"compact renumber":      {[]EditOption{KVCompact(), Renumber()}, []uint64{1, 2}, DropCounts{KVCompact: 7}, 0, 5},
+		"content filter first":  {[]EditOption{KVCompact(), NoHeader("KV-Operation")}, []uint64{2, 3, 7}, DropCounts{Header: 3, KVCompact: 3}, 2, 4},
+		"sequence filter first": {[]EditOption{KVCompact(), LastSeq(5)}, []uint64{3, 5}, DropCounts{Sequence: 4, KVCompact: 3}, 0, 3},
+		"subject filter first":  {[]EditOption{KVCompact(), Subjects("$KV.orders.b", "$KV.orders.d")}, []uint64{8}, DropCounts{Subject: 5, KVCompact: 3}, 0, 2},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := kvDir(t, kvConfig())
+			dst, res := edit(t, src, tc.opts...)
+			if _, err := Verify(dst); err != nil {
+				t.Fatalf("output does not verify: %v", err)
+			}
+			if got := seqsOf(messagesOf(readItems(t, dst))); !reflect.DeepEqual(got, tc.seqs) {
+				t.Fatalf("kept %v, want %v", got, tc.seqs)
+			}
+			if res.Report.Dropped != tc.dropped || res.Report.TombstonesRemovedByContentFilters != tc.tombs || res.Report.SubjectStateKeys != tc.keys {
+				t.Fatalf("report %+v", res.Report)
+			}
+		})
+	}
+}
+
+func TestEditKVCompactGate(t *testing.T) {
+	cfg := kvConfig()
+	cfg.Subjects = []string{"$KV.orders.>", "extra"}
+	src := kvDir(t, cfg)
+	_, err := Edit(context.Background(), src, filepath.Join(t.TempDir(), "dst"), KVCompact())
+	if err == nil || !strings.Contains(err.Error(), "KVCompact requires a KV bucket backup") {
+		t.Fatalf("expected the KV gate to refuse, got %v", err)
+	}
+
+	cfg = kvConfig()
+	cfg.Name = "KV_other"
+	src = kvDir(t, cfg)
+	_, err = Edit(context.Background(), src, filepath.Join(t.TempDir(), "dst"), KVCompact())
+	if err == nil || !strings.Contains(err.Error(), "KVCompact requires a KV bucket backup") {
+		t.Fatalf("expected the KV gate to refuse a mismatched bucket, got %v", err)
+	}
+}
+
+func TestEditTwoPassDryRun(t *testing.T) {
+	src := kvDir(t, kvConfig())
+	dst := filepath.Join(t.TempDir(), "dry")
+	dry, err := Edit(context.Background(), src, dst, KVCompact(), DryRun())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		t.Fatal("dry run wrote the target")
+	}
+	_, real := edit(t, src, KVCompact())
+	if !reflect.DeepEqual(dry, real) {
+		t.Fatalf("dry run result differs:\n%+v\n%+v", dry, real)
+	}
+}
+
+func TestEditTwoPassSurvivesRenameSwap(t *testing.T) {
+	src := kvDir(t, kvConfig())
+	original, _ := os.ReadFile(filepath.Join(src, DataFile))
+
+	swap := func() {
+		other := encodeBackup(t, fixtureState(), nil, []testMsg{{"$KV.orders.z", 1, 1, "", "z"}}, true)
+		tmp := filepath.Join(src, "replacement")
+		if err := os.WriteFile(tmp, other, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(tmp, filepath.Join(src, DataFile)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dst, res := edit(t, src, KVCompact(), betweenPasses(swap))
+	if got := seqsOf(messagesOf(readItems(t, dst))); !reflect.DeepEqual(got, []uint64{3, 8}) {
+		t.Fatalf("second pass did not read the held file: %v", got)
+	}
+	sc := loadMetaFile(t, dst)
+	if res.Report.Kept != 2 || !strings.HasPrefix(sc.Edit.SourceDigest, "sha256:") {
+		t.Fatalf("unexpected result %+v", res.Report)
+	}
+	if now, _ := os.ReadFile(filepath.Join(src, DataFile)); bytes.Equal(now, original) {
+		t.Fatal("the swap did not happen")
+	}
+}
+
+func TestEditTwoPassDetectsInPlaceChange(t *testing.T) {
+	src := kvDir(t, kvConfig())
+	parent := t.TempDir()
+
+	appendJunk := func() {
+		f, err := os.OpenFile(filepath.Join(src, DataFile), os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Write([]byte("trailing junk"))
+		f.Close()
+	}
+
+	_, err := Edit(context.Background(), src, filepath.Join(parent, "dst"), KVCompact(), betweenPasses(appendJunk))
+	if err == nil || !strings.Contains(err.Error(), "changed during the edit") {
+		t.Fatalf("expected the in-place change to be detected, got %v", err)
+	}
+	if entries, _ := os.ReadDir(parent); len(entries) != 0 {
+		t.Fatalf("failed edit left files behind: %v", entries)
+	}
+}

--- a/backup/verify.go
+++ b/backup/verify.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nats-io/jsm.go/api"
+)
+
+// VerifyReport summarizes a scan of a backup directory
+type VerifyReport struct {
+	// Entries is the number of archive entries that decoded cleanly
+	Entries   int
+	Consumers int
+	Messages  uint64
+	// FirstSeq and LastSeq are the first and last message sequences found, 0 when empty
+	FirstSeq uint64
+	LastSeq  uint64
+	// Complete is true once the end-of-backup sentinel was reached
+	Complete bool
+	// LastGood identifies the last entry that decoded cleanly
+	LastGood EntryRef
+}
+
+// InfoReport describes a backup directory from a full scan of its archive
+type InfoReport struct {
+	// Config is the stream configuration from the meta file
+	Config api.StreamConfig `json:"config"`
+	// Declared is the state.json inside the archive; its messages and bytes
+	// are advisory and may be 0 in an edited backup
+	Declared api.StreamState `json:"declared"`
+	// DeclaredCountsAdvisory is true when Declared carries 0 messages or bytes
+	// while the archive holds messages
+	DeclaredCountsAdvisory bool `json:"declared_counts_advisory"`
+	// Edit is the meta file's edit block when the backup was produced by Edit
+	Edit *EditInfo `json:"edit,omitempty"`
+	// Consumers are the consumer names in archive order
+	Consumers []string `json:"consumers"`
+	// Messages is the number of messages in the archive
+	Messages uint64 `json:"messages"`
+	// Bytes is the storage the messages will occupy on restore, per the file store's accounting
+	Bytes uint64 `json:"bytes"`
+	// FirstSeq and LastSeq bound the message sequences in the archive, 0 when empty
+	FirstSeq uint64 `json:"first_seq"`
+	LastSeq  uint64 `json:"last_seq"`
+	// FirstTime and LastTime bound the message timestamps, zero when empty
+	FirstTime time.Time `json:"first_time"`
+	LastTime  time.Time `json:"last_time"`
+}
+
+// Verify checks that dir holds a complete, restorable 2.15 stream backup: a
+// parseable meta file and an archive whose entries satisfy every invariant the
+// server's restore enforces, terminated by the sentinel. A nil error means
+// valid; when the archive fails part way the report and the error name the
+// last good entry
+func Verify(dir string) (*VerifyReport, error) {
+	_, report, err := scan(dir)
+	return report, err
+}
+
+// Info scans a backup directory to the sentinel and reports what it holds
+func Info(dir string) (*InfoReport, error) {
+	info, _, err := scan(dir)
+	return info, err
+}
+
+func scan(dir string) (*InfoReport, *VerifyReport, error) {
+	data, meta, err := backupPaths(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mf, err := readMetaFile(meta)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f, err := os.Open(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	info := &InfoReport{Config: mf.Config, Edit: mf.Edit}
+	report := &VerifyReport{}
+	dec := NewDecoder(f)
+	for {
+		item, err := dec.Next()
+		if err != nil {
+			report.LastGood = dec.LastGood()
+			report.FirstSeq = info.FirstSeq
+			report.LastSeq = info.LastSeq
+			return nil, report, fmt.Errorf("%s: %w (last good entry: %s)", data, err, report.LastGood)
+		}
+
+		report.Entries++
+		switch it := item.(type) {
+		case *State:
+			info.Declared = it.State
+		case *Consumer:
+			info.Consumers = append(info.Consumers, it.Name)
+			report.Consumers++
+		case *Message:
+			info.Messages++
+			report.Messages++
+			info.Bytes += storedMsgSize(len(it.Subject), it.HdrSize, it.PayloadSize)
+			if info.FirstSeq == 0 {
+				info.FirstSeq = it.Seq
+				info.FirstTime = time.Unix(0, it.Ts).UTC()
+			}
+			info.LastSeq = it.Seq
+			info.LastTime = time.Unix(0, it.Ts).UTC()
+		case End:
+			report.Complete = true
+			report.LastGood = dec.LastGood()
+			report.FirstSeq = info.FirstSeq
+			report.LastSeq = info.LastSeq
+			info.DeclaredCountsAdvisory = info.Messages > 0 && (info.Declared.Msgs == 0 || info.Declared.Bytes == 0)
+			return info, report, nil
+		}
+	}
+}

--- a/natscontext/svcbackend/cmd/svcbackend-conformance/checks_atomicity.go
+++ b/natscontext/svcbackend/cmd/svcbackend-conformance/checks_atomicity.go
@@ -110,6 +110,5 @@ func atomicityChecks() []Check {
 				return StatusWarn, fmt.Sprintf("no torn reads observed in %d observations over %d writes (probabilistic)", reads.Load(), h.Iterations), nil
 			},
 		},
-
 	}
 }

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -1,0 +1,603 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/jsm.go/api"
+	"github.com/nats-io/jsm.go/backup"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	ntfclient "github.com/synadia-io/orbit.go/ntf-client"
+)
+
+func deleteMsg(t testing.TB, stream *jsm.Stream, seq uint64) {
+	t.Helper()
+	checkErr(t, stream.DeleteMessageRequest(api.JSApiMsgDeleteRequest{Seq: seq}), "delete failed")
+}
+
+func snapshotFixture(t testing.TB, mgr *jsm.Manager, stream *jsm.Stream) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "src")
+	_, err := stream.SnapshotToDirectory(context.Background(), dir, jsm.SnapshotConsumers())
+	checkErr(t, err, "snapshot failed")
+	return dir
+}
+
+func publishMsg(t testing.TB, nc *nats.Conn, subject, body string, hdr ...string) {
+	t.Helper()
+	msg := nats.NewMsg(subject)
+	msg.Data = []byte(body)
+	for i := 0; i+1 < len(hdr); i += 2 {
+		msg.Header.Add(hdr[i], hdr[i+1])
+	}
+	_, err := nc.RequestMsg(msg, time.Second)
+	checkErr(t, err, "publish failed")
+}
+
+func TestBackupVerifyAndInfoOnServerSnapshot(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		stream, err := mgr.NewStream("ORDERS", jsm.FileStorage(), jsm.Subjects("orders.>"))
+		checkErr(t, err, "create failed")
+		_, err = stream.NewConsumer(jsm.DurableName("c1"), jsm.FilterStreamBySubject("orders.new"))
+		checkErr(t, err, "consumer failed")
+		_, err = stream.NewConsumer(jsm.DurableName("c2"))
+		checkErr(t, err, "consumer failed")
+
+		for i := 1; i <= 20; i++ {
+			msg := nats.NewMsg(fmt.Sprintf("orders.%s", []string{"new", "paid"}[i%2]))
+			msg.Data = []byte(RandomString(100 * i))
+			if i%3 == 0 {
+				msg.Header.Set("X-Batch", fmt.Sprintf("%d", i))
+			}
+			_, err := nc.RequestMsg(msg, time.Second)
+			checkErr(t, err, "publish failed")
+		}
+		deleteMsg(t, stream, 1)
+		deleteMsg(t, stream, 7)
+
+		state, err := stream.State()
+		checkErr(t, err, "state failed")
+
+		dir := snapshotFixture(t, mgr, stream)
+
+		rep, err := backup.Verify(dir)
+		checkErr(t, err, "verify failed")
+		if !rep.Complete || rep.Entries != 22 || rep.Consumers != 2 || rep.Messages != state.Msgs || rep.FirstSeq != state.FirstSeq || rep.LastSeq != state.LastSeq {
+			t.Fatalf("unexpected report: %+v vs state %+v", rep, state)
+		}
+
+		info, err := backup.Info(dir)
+		checkErr(t, err, "info failed")
+		if info.Config.Name != "ORDERS" || !reflect.DeepEqual(info.Config.Subjects, []string{"orders.>"}) {
+			t.Fatalf("unexpected config: %+v", info.Config)
+		}
+		if info.Messages != state.Msgs || info.FirstSeq != state.FirstSeq || info.LastSeq != state.LastSeq {
+			t.Fatalf("unexpected counts: %+v vs %+v", info, state)
+		}
+		if info.Bytes != state.Bytes {
+			t.Fatalf("stored size mirror disagrees with the server: %d vs %d", info.Bytes, state.Bytes)
+		}
+		if !info.FirstTime.Equal(state.FirstTime) || !info.LastTime.Equal(state.LastTime) {
+			t.Fatalf("unexpected times: %v-%v vs %v-%v", info.FirstTime, info.LastTime, state.FirstTime, state.LastTime)
+		}
+		if len(info.Consumers) != 2 || info.DeclaredCountsAdvisory || info.Declared.Msgs != state.Msgs || info.Declared.Consumers != 2 || info.Edit != nil {
+			t.Fatalf("unexpected declared state: %+v", info)
+		}
+
+		deleteMsg(t, stream, 20)
+		state, err = stream.State()
+		checkErr(t, err, "state failed")
+		dir = snapshotFixture(t, mgr, stream)
+		info, err = backup.Info(dir)
+		checkErr(t, err, "info failed")
+		if info.LastSeq != 19 || info.Declared.LastSeq != 20 || state.LastSeq != 20 || info.Messages != state.Msgs {
+			t.Fatalf("trailing delete not reflected: archive last %d, declared last %d, state %+v", info.LastSeq, info.Declared.LastSeq, state)
+		}
+	})
+}
+
+type editFixture struct {
+	nc     *nats.Conn
+	mgr    *jsm.Manager
+	dir    string
+	pre    api.StreamState
+	mid    time.Time
+	bodies map[uint64]string
+}
+
+func newEditFixture(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, streamOpts ...jsm.StreamOption) *editFixture {
+	t.Helper()
+
+	opts := append([]jsm.StreamOption{jsm.FileStorage(), jsm.Subjects("orders.>", "audit.*")}, streamOpts...)
+	stream, err := mgr.NewStream("ORDERS", opts...)
+	checkErr(t, err, "create failed")
+	_, err = stream.NewConsumer(jsm.DurableName("c1"), jsm.FilterStreamBySubject("orders.new"))
+	checkErr(t, err, "consumer failed")
+	_, err = stream.NewConsumer(jsm.DurableName("c2"))
+	checkErr(t, err, "consumer failed")
+
+	first := stream.FirstSequence()
+	if first == 0 {
+		first = 1
+	}
+	f := &editFixture{nc: nc, mgr: mgr, bodies: map[uint64]string{}}
+	publish := func(offset uint64, subject, body string, hdr ...string) {
+		publishMsg(t, nc, subject, body, hdr...)
+		f.bodies[first+offset] = body
+	}
+
+	publish(0, "orders.new", "order 1")
+	publish(1, "orders.paid", "paid 1", "X-Batch", "7")
+	publish(2, "orders.new", "order 2 urgent", "X-Batch", "7")
+	time.Sleep(10 * time.Millisecond)
+	f.mid = time.Now()
+	time.Sleep(10 * time.Millisecond)
+	publish(3, "audit.log", "audit entry")
+	publish(4, "orders.shipped", "shipped urgent", "X-Batch", "8")
+	publish(5, "orders.paid", "paid 2")
+	deleteMsg(t, stream, first+3)
+	delete(f.bodies, first+3)
+
+	f.pre, err = stream.State()
+	checkErr(t, err, "state failed")
+	f.dir = snapshotFixture(t, mgr, stream)
+	checkErr(t, stream.Delete(), "delete failed")
+
+	return f
+}
+
+func (f *editFixture) editAndRestore(t testing.TB, opts ...backup.EditOption) (*backup.Result, *jsm.Stream, api.StreamState) {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), "edited")
+	res, err := backup.Edit(context.Background(), f.dir, dst, opts...)
+	checkErr(t, err, "edit failed")
+	_, err = backup.Verify(dst)
+	checkErr(t, err, "edited backup does not verify")
+
+	_, st, err := f.mgr.RestoreSnapshotFromDirectory(context.Background(), "ORDERS", dst)
+	checkErr(t, err, "restore failed")
+	stream, err := f.mgr.LoadStream("ORDERS")
+	checkErr(t, err, "load failed")
+
+	if st.Bytes != res.State.Bytes {
+		t.Fatalf("restored bytes %d differ from the meta file's %d", st.Bytes, res.State.Bytes)
+	}
+	if st.Msgs != res.State.Msgs || st.FirstSeq != res.State.FirstSeq || st.LastSeq != res.State.LastSeq || st.Consumers != res.State.Consumers {
+		t.Fatalf("restored state %+v disagrees with the meta file %+v", st, res.State)
+	}
+
+	return res, stream, *st
+}
+
+func presentSeqs(t testing.TB, stream *jsm.Stream, st api.StreamState, bodies map[uint64]string) []uint64 {
+	t.Helper()
+	var seqs []uint64
+	if st.Msgs == 0 {
+		return seqs
+	}
+	for seq := st.FirstSeq; seq <= st.LastSeq; seq++ {
+		msg, err := stream.ReadMessage(seq)
+		if err != nil {
+			continue
+		}
+		if string(msg.Data) != bodies[seq] {
+			t.Fatalf("seq %d restored with body %q, want %q", seq, msg.Data, bodies[seq])
+		}
+		seqs = append(seqs, seq)
+	}
+	return seqs
+}
+
+func TestBackupEditIdentityRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		res, stream, st := f.editAndRestore(t)
+
+		if !reflect.DeepEqual(f.pre, st) {
+			t.Fatalf("restored state differs from the source:\n%+v\n%+v", f.pre, st)
+		}
+		if !reflect.DeepEqual(presentSeqs(t, stream, st, f.bodies), []uint64{1, 2, 3, 5, 6}) {
+			t.Fatal("restored messages differ from the source")
+		}
+		names, err := stream.ConsumerNames()
+		checkErr(t, err, "consumer names failed")
+		if !reflect.DeepEqual(names, []string{"c1", "c2"}) {
+			t.Fatalf("unexpected consumers %v", names)
+		}
+		if res.Report.Kept != 5 || res.Report.ConsumersKept != 2 {
+			t.Fatalf("unexpected report %+v", res.Report)
+		}
+	})
+}
+
+func TestBackupEditFiltersRestore(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		res, stream, st := f.editAndRestore(t, backup.Subjects("orders.>"), backup.Before(f.mid), backup.HeaderPresent("X-Batch"), backup.ExcludePayloadMatch(regexp.MustCompile("urgent")))
+
+		if got := presentSeqs(t, stream, st, f.bodies); !reflect.DeepEqual(got, []uint64{2}) {
+			t.Fatalf("restored seqs %v, want [2]", got)
+		}
+		if st.FirstSeq != 2 || st.LastSeq != 6 || st.Msgs != 1 || st.NumDeleted != 4 {
+			t.Fatalf("preserve must keep source sequences with gaps up to the source last: %+v", st)
+		}
+		if st.Consumers != 2 || res.Report.Kept != 1 || res.Report.SourceMessages != 5 {
+			t.Fatalf("unexpected state %+v report %+v", st, res.Report)
+		}
+	})
+}
+
+func TestBackupEditRenumberRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr, jsm.FirstSequence(1000))
+		if f.pre.FirstSeq != 1000 || f.pre.LastSeq != 1005 {
+			t.Fatalf("fixture not numbered from 1000: %+v", f.pre)
+		}
+
+		res, stream, st := f.editAndRestore(t, backup.Renumber(), backup.ExcludeSubjects("audit.*"))
+		if st.FirstSeq != 1 || st.LastSeq != 5 || st.Msgs != 5 || st.NumDeleted != 0 || st.Consumers != 0 {
+			t.Fatalf("unexpected restored state %+v", st)
+		}
+		if stream.FirstSequence() != 0 || res.Config.FirstSeq != 0 {
+			t.Fatalf("renumber must clear the configured first sequence: %d", stream.FirstSequence())
+		}
+
+		want := []string{"order 1", "paid 1", "order 2 urgent", "shipped urgent", "paid 2"}
+		for i, body := range want {
+			msg, err := stream.ReadMessage(uint64(i + 1))
+			checkErr(t, err, "read failed")
+			if string(msg.Data) != body {
+				t.Fatalf("seq %d has %q, want %q", i+1, msg.Data, body)
+			}
+		}
+		names, err := stream.ConsumerNames()
+		checkErr(t, err, "consumer names failed")
+		if len(names) != 0 {
+			t.Fatalf("renumber must drop consumers, got %v", names)
+		}
+
+		publishMsg(t, f.nc, "orders.new", "after restore")
+		st, err = stream.State()
+		checkErr(t, err, "state failed")
+		if st.LastSeq != 6 || st.Msgs != 6 {
+			t.Fatalf("stream did not continue at 6: %+v", st)
+		}
+	})
+}
+
+func TestBackupEditEmptyResultRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		_, stream, st := f.editAndRestore(t, backup.Subjects("nothing.*"))
+		if st.Msgs != 0 || st.FirstSeq != 7 || st.LastSeq != 6 || st.Consumers != 2 {
+			t.Fatalf("expected an empty stream at last+1/last, got %+v", st)
+		}
+
+		publishMsg(t, f.nc, "orders.new", "after restore")
+		st, err := stream.State()
+		checkErr(t, err, "state failed")
+		if st.FirstSeq != 7 || st.LastSeq != 7 {
+			t.Fatalf("stream did not continue at 7: %+v", st)
+		}
+	})
+}
+
+func TestBackupEditEmptyRenumberRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		_, stream, st := f.editAndRestore(t, backup.Subjects("nothing.*"), backup.Renumber())
+		if st.Msgs != 0 || st.FirstSeq != 1 || st.LastSeq != 0 || st.Consumers != 0 {
+			t.Fatalf("expected an empty stream at 1/0, got %+v", st)
+		}
+
+		publishMsg(t, f.nc, "orders.new", "after restore")
+		st, err := stream.State()
+		checkErr(t, err, "state failed")
+		if st.FirstSeq != 1 || st.LastSeq != 1 {
+			t.Fatalf("stream did not start at 1: %+v", st)
+		}
+	})
+}
+
+type kvFixture struct {
+	nc   *nats.Conn
+	js   nats.JetStreamContext
+	mgr  *jsm.Manager
+	dir  string
+	revA uint64
+	msgs uint64
+}
+
+func newKVFixture(t testing.TB, nc *nats.Conn, mgr *jsm.Manager) *kvFixture {
+	t.Helper()
+
+	js, err := nc.JetStream()
+	checkErr(t, err, "jetstream failed")
+	kv, err := js.CreateKeyValue(&nats.KeyValueConfig{Bucket: "orders", History: 5})
+	checkErr(t, err, "bucket failed")
+
+	put := func(key, value string) {
+		_, err := kv.Put(key, []byte(value))
+		checkErr(t, err, "put failed")
+	}
+	put("a", "a1")
+	put("a", "a2")
+	put("b", "b1")
+	checkErr(t, kv.Delete("b"), "delete failed")
+	put("c", "c1")
+	checkErr(t, kv.Purge("c"), "purge failed")
+	put("d", "d1")
+	put("e", "e1")
+	publishMsg(t, nc, "$KV.orders.e", "", "Nats-Marker-Reason", "MaxAge")
+	put("f", "f1")
+	publishMsg(t, nc, "$KV.orders.f", "f2", "KV-Operation", "FOO", "Nats-Marker-Reason", "Remove")
+
+	entry, err := kv.Get("a")
+	checkErr(t, err, "get failed")
+
+	stream, err := mgr.LoadStream("KV_orders")
+	checkErr(t, err, "load failed")
+	st, err := stream.State()
+	checkErr(t, err, "state failed")
+
+	f := &kvFixture{nc: nc, js: js, mgr: mgr, revA: entry.Revision(), msgs: st.Msgs}
+	f.dir = snapshotFixture(t, mgr, stream)
+	checkErr(t, stream.Delete(), "delete failed")
+
+	return f
+}
+
+func (f *kvFixture) editAndRestore(t testing.TB, opts ...backup.EditOption) (*backup.Result, nats.KeyValue) {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), "edited")
+	res, err := backup.Edit(context.Background(), f.dir, dst, opts...)
+	checkErr(t, err, "edit failed")
+	_, err = backup.Verify(dst)
+	checkErr(t, err, "edited backup does not verify")
+
+	_, st, err := f.mgr.RestoreSnapshotFromDirectory(context.Background(), "KV_orders", dst)
+	checkErr(t, err, "restore failed")
+	if st.Msgs != res.State.Msgs || st.Bytes != res.State.Bytes || st.FirstSeq != res.State.FirstSeq || st.LastSeq != res.State.LastSeq {
+		t.Fatalf("restored state %+v disagrees with the meta file %+v", st, res.State)
+	}
+
+	kv, err := f.js.KeyValue("orders")
+	checkErr(t, err, "bucket load failed")
+	return res, kv
+}
+
+func expectValue(t testing.TB, kv nats.KeyValue, key, value string) nats.KeyValueEntry {
+	t.Helper()
+	entry, err := kv.Get(key)
+	checkErr(t, err, "get "+key+" failed")
+	if string(entry.Value()) != value {
+		t.Fatalf("key %s has %q, want %q", key, entry.Value(), value)
+	}
+	history, err := kv.History(key)
+	checkErr(t, err, "history failed")
+	if len(history) != 1 {
+		t.Fatalf("key %s has %d revisions after compaction", key, len(history))
+	}
+	return entry
+}
+
+func expectAbsent(t testing.TB, kv nats.KeyValue, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		if _, err := kv.Get(key); !errors.Is(err, nats.ErrKeyNotFound) {
+			t.Fatalf("key %s should be gone, got %v", key, err)
+		}
+		if _, err := kv.History(key); !errors.Is(err, nats.ErrKeyNotFound) {
+			t.Fatalf("key %s should have no history, got %v", key, err)
+		}
+	}
+}
+
+func TestBackupEditKVCompactRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newKVFixture(t, nc, mgr)
+		res, kv := f.editAndRestore(t, backup.KVCompact())
+
+		a := expectValue(t, kv, "a", "a2")
+		expectValue(t, kv, "d", "d1")
+		expectValue(t, kv, "f", "f2")
+		expectAbsent(t, kv, "b", "c", "e")
+
+		if a.Revision() != f.revA {
+			t.Fatalf("preserve must keep revisions: %d vs %d", a.Revision(), f.revA)
+		}
+		if _, err := kv.Update("a", []byte("a3"), f.revA); err != nil {
+			t.Fatalf("compare-and-set with the pre-edit revision failed: %v", err)
+		}
+
+		keys, err := kv.Keys()
+		checkErr(t, err, "keys failed")
+		if !reflect.DeepEqual(keys, []string{"a", "d", "f"}) {
+			t.Fatalf("unexpected keys %v", keys)
+		}
+		if res.Report.Kept != 3 || res.Report.SourceMessages != f.msgs || res.Report.Dropped.KVCompact != f.msgs-3 || res.Report.SubjectStateKeys != 6 {
+			t.Fatalf("unexpected report %+v", res.Report)
+		}
+
+		stream, err := f.mgr.LoadStream("KV_orders")
+		checkErr(t, err, "load failed")
+		checkErr(t, stream.Delete(), "delete failed")
+
+		res, kv = f.editAndRestore(t, backup.KVCompact(), backup.Renumber())
+		a = expectValue(t, kv, "a", "a2")
+		if a.Revision() != 1 || res.State.FirstSeq != 1 || res.State.LastSeq != 3 {
+			t.Fatalf("renumber should number survivors from 1: revision %d state %+v", a.Revision(), res.State)
+		}
+		if _, err := kv.Update("a", []byte("a3"), f.revA); err == nil {
+			t.Fatal("compare-and-set with the pre-edit revision must fail after renumbering")
+		}
+		if _, err := kv.Update("a", []byte("a3"), 1); err != nil {
+			t.Fatalf("compare-and-set with the new revision failed: %v", err)
+		}
+	})
+}
+
+func TestBackupEditLastPerSubjectRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		res, stream, st := f.editAndRestore(t, backup.LastPerSubject(1))
+		if got := presentSeqs(t, stream, st, f.bodies); !reflect.DeepEqual(got, []uint64{3, 5, 6}) {
+			t.Fatalf("restored seqs %v", got)
+		}
+		if st.FirstSeq != 3 || st.LastSeq != 6 || st.Consumers != 2 || res.Report.Dropped.LastPerSubject != 2 {
+			t.Fatalf("unexpected state %+v report %+v", st, res.Report)
+		}
+	})
+
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		_, stream, st := f.editAndRestore(t, backup.LastPerSubject(1), backup.Renumber())
+		if st.FirstSeq != 1 || st.LastSeq != 3 || st.Msgs != 3 || st.Consumers != 0 {
+			t.Fatalf("unexpected renumbered state %+v", st)
+		}
+		for seq, body := range map[uint64]string{1: "order 2 urgent", 2: "shipped urgent", 3: "paid 2"} {
+			msg, err := stream.ReadMessage(seq)
+			checkErr(t, err, "read failed")
+			if string(msg.Data) != body {
+				t.Fatalf("seq %d has %q, want %q", seq, msg.Data, body)
+			}
+		}
+	})
+}
+
+func obfuscationMap(t testing.TB, path string) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	checkErr(t, err, "key file read failed")
+	var kf struct {
+		Map map[string]string `json:"map"`
+	}
+	checkErr(t, json.Unmarshal(raw, &kf), "key file parse failed")
+	originals := map[string]string{}
+	for hashed, original := range kf.Map {
+		originals[original] = hashed
+	}
+	return originals
+}
+
+func TestBackupEditObfuscateRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newEditFixture(t, nc, mgr)
+		dst := filepath.Join(t.TempDir(), "edited")
+		res, err := backup.Edit(context.Background(), f.dir, dst, backup.Obfuscate())
+		checkErr(t, err, "edit failed")
+		_, err = backup.Verify(dst)
+		checkErr(t, err, "edited backup does not verify")
+
+		originals := obfuscationMap(t, res.Report.Obfuscation.KeyFile)
+		if res.Config.Name != originals["ORDERS"] || strings.Contains(res.Config.Name, "ORDERS") {
+			t.Fatalf("stream name not hashed: %q", res.Config.Name)
+		}
+
+		_, st, err := f.mgr.RestoreSnapshotFromDirectory(context.Background(), res.Config.Name, dst)
+		checkErr(t, err, "restore of the obfuscated backup failed")
+		if st.Msgs != res.State.Msgs || st.Bytes != res.State.Bytes || st.FirstSeq != res.State.FirstSeq || st.LastSeq != res.State.LastSeq || st.Consumers != 2 {
+			t.Fatalf("restored state %+v disagrees with the meta file %+v", st, res.State)
+		}
+
+		stream, err := f.mgr.LoadStream(res.Config.Name)
+		checkErr(t, err, "load failed")
+		names, err := stream.ConsumerNames()
+		checkErr(t, err, "consumer names failed")
+		want := []string{originals["c1"], originals["c2"]}
+		slices.Sort(want)
+		if !slices.Equal(names, want) {
+			t.Fatalf("consumers not restored under hashed names: %v", names)
+		}
+		c1, err := stream.LoadConsumer(originals["c1"])
+		checkErr(t, err, "consumer load failed")
+		if c1.FilterSubject() != originals["orders"]+"."+originals["new"] {
+			t.Fatalf("consumer filter not hashed consistently: %q", c1.FilterSubject())
+		}
+
+		msg, err := stream.ReadMessage(2)
+		checkErr(t, err, "read failed")
+		if len(msg.Data) != 0 || msg.Subject != originals["orders"]+"."+originals["paid"] {
+			t.Fatalf("message not obfuscated: %+v", msg)
+		}
+		hdr, err := nats.DecodeHeadersMsg(msg.Header)
+		checkErr(t, err, "header decode failed")
+		if hdr.Get("X-Batch") != originals["7"] {
+			t.Fatalf("header value not hashed: %v", hdr)
+		}
+	})
+}
+
+func TestBackupEditObfuscateKVRestores(t *testing.T) {
+	withJSServer(t, func(t testing.TB, nc *nats.Conn, mgr *jsm.Manager, _ *ntfclient.Instance) {
+		f := newKVFixture(t, nc, mgr)
+		dst := filepath.Join(t.TempDir(), "edited")
+		res, err := backup.Edit(context.Background(), f.dir, dst, backup.Obfuscate())
+		checkErr(t, err, "edit failed")
+		originals := obfuscationMap(t, res.Report.Obfuscation.KeyFile)
+
+		_, st, err := f.mgr.RestoreSnapshotFromDirectory(context.Background(), res.Config.Name, dst)
+		checkErr(t, err, "restore failed")
+		if st.Msgs != res.State.Msgs || st.Bytes != res.State.Bytes {
+			t.Fatalf("restored state %+v disagrees with the meta file %+v", st, res.State)
+		}
+
+		ctx := context.Background()
+		js, err := jetstream.New(f.nc)
+		checkErr(t, err, "jetstream failed")
+		kv, err := js.KeyValue(ctx, originals["orders"])
+		checkErr(t, err, "bucket load failed")
+		for _, key := range []string{"a", "d", "f"} {
+			entry, err := kv.Get(ctx, originals[key])
+			checkErr(t, err, "get "+key+" failed")
+			if len(entry.Value()) != 0 {
+				t.Fatalf("value of %s survived obfuscation: %q", key, entry.Value())
+			}
+		}
+		keys, err := kv.Keys(ctx)
+		checkErr(t, err, "keys failed")
+		if len(keys) != 3 {
+			t.Fatalf("expected only a, d and f to be live, got %v", keys)
+		}
+		for key, want := range map[string]jetstream.KeyValueOp{"b": jetstream.KeyValueDelete, "c": jetstream.KeyValuePurge, "e": jetstream.KeyValuePurge} {
+			if _, err := kv.Get(ctx, originals[key]); !errors.Is(err, jetstream.ErrKeyNotFound) {
+				t.Fatalf("tombstone of %s lost: %v", key, err)
+			}
+			history, err := kv.History(ctx, originals[key])
+			checkErr(t, err, "history of "+key+" failed")
+			if got := history[len(history)-1].Operation(); got != want {
+				t.Fatalf("latest op of %s is %v, want %v", key, got, want)
+			}
+		}
+		history, err := kv.History(ctx, originals["a"])
+		checkErr(t, err, "history failed")
+		if len(history) != 2 {
+			t.Fatalf("key a has %d revisions, want 2", len(history))
+		}
+	})
+}

--- a/test/consumers_test.go
+++ b/test/consumers_test.go
@@ -720,7 +720,7 @@ func TestMaxDeliveryAttempts(t *testing.T) {
 	cfg := testConsumerConfig()
 	jsm.MaxDeliveryAttempts(10)(cfg)
 	if cfg.MaxDeliver != 10 {
-		t.Fatalf("expected 10 got %v", cfg.MaxDeliver)
+		t.Fatalf("expected 10 got %d", cfg.MaxDeliver)
 	}
 
 	err := jsm.MaxDeliveryAttempts(0)


### PR DESCRIPTION
Adds a backup package that verifies, inspects and edits NATS Server 2.15 directory backups without a server connection. Edits filter by subject, time, sequence, header and payload, can keep the newest N messages per subject or compact a KV bucket to its latest revisions, and can renumber the result. An obfuscate option produces a shareable copy with names and subjects replaced by keyed hashes and message bodies dropped, writing the reverse mapping to a key file beside the target. Sequences and consumers are preserved by default so drops restore as deleted gaps, and the same input, options and key file always produce a byte-identical output.