### PR TITLE
(maint) Address post-merge review comments on the backup package

### DIFF
--- a/backup/edit.go
+++ b/backup/edit.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -510,10 +511,18 @@ func (e *editor) writeMessage(body *msgBody) error {
 		if err != nil {
 			return err
 		}
-		if m.PayloadSize > 0 {
-			e.obf.bodies++
+		if e.cfg.AllowMsgCounter {
+			payload, err := body.payload()
+			if err != nil {
+				return err
+			}
+			out.Subject, out.HdrSize, out.Body = subject, int64(len(block)), io.MultiReader(bytes.NewReader(block), bytes.NewReader(payload))
+		} else {
+			if m.PayloadSize > 0 {
+				e.obf.bodies++
+			}
+			out.Subject, out.HdrSize, out.PayloadSize, out.Body = subject, int64(len(block)), 0, bytes.NewReader(block)
 		}
-		out.Subject, out.HdrSize, out.PayloadSize, out.Body = subject, int64(len(block)), 0, bytes.NewReader(block)
 	} else {
 		out.Body = body.reader()
 	}

--- a/backup/obfuscate.go
+++ b/backup/obfuscate.go
@@ -353,7 +353,8 @@ func (o *obfuscator) consumer(name string, data []byte) (string, []byte, error) 
 // message rewrites a message's subject and headers; control headers stay
 // verbatim, subject-valued headers are token hashed and every other value
 // is hashed whole. Headers are written in key order so the output is
-// deterministic. The body is dropped by the caller
+// deterministic. The caller drops the body, except on counter streams
+// where the body is the running total the restored counter needs
 func (o *obfuscator) message(subject string, h nats.Header) (string, []byte, error) {
 	subj, err := o.subject(subject)
 	if err != nil {
@@ -381,7 +382,7 @@ func (o *obfuscator) message(subject string, h nats.Header) (string, []byte, err
 func (o *obfuscator) headerValue(key, val string) (string, error) {
 	switch {
 	case equalsAny(key, server.KVOperation, server.JSMarkerReason, server.JSMessageTTL, server.JSMsgRollup, server.JSExpectedLastSubjSeq,
-		server.JSSchedulePattern, server.JSScheduleTTL, server.JSScheduleTimeZone):
+		server.JSSchedulePattern, server.JSScheduleTTL, server.JSScheduleTimeZone, server.JSMessageIncr):
 		return val, nil
 	case equalsAny(key, server.JSExpectedLastSubjSeqSubj, server.JSScheduleTarget, server.JSScheduleSource):
 		return o.subject(val)
@@ -412,9 +413,12 @@ func keyFilePath(target string) string {
 	return filepath.Clean(target) + keyFileSuffix
 }
 
-// writeKeyFile refuses to clobber a key file it did not read this run and
-// replaces the file atomically, so the input key file is never left
-// truncated. It reports whether the file is new
+// writeKeyFile stages the mappings in a synced temp file and links it to
+// the final path, which claims the name atomically and never exposes a
+// partial file, so a crash leaves no key file to block a retry and
+// concurrent edits cannot delete each other's mappings. The input key
+// file is instead replaced through a rename and is never left truncated.
+// It reports whether the file is new
 func (o *obfuscator) writeKeyFile(path string, inputKeyFile string) (created bool, err error) {
 	same := false
 	if inputKeyFile != "" {
@@ -422,18 +426,12 @@ func (o *obfuscator) writeKeyFile(path string, inputKeyFile string) (created boo
 		b, errB := filepath.Abs(path)
 		same = errA == nil && errB == nil && a == b
 	}
-	if !same {
-		if _, err := os.Stat(path); err == nil {
-			return false, fmt.Errorf("key file %s already exists", path)
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return false, err
-		}
-	}
 
 	data, err := o.keyFileBytes()
 	if err != nil {
 		return false, err
 	}
+
 	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*")
 	if err != nil {
 		return false, err
@@ -450,8 +448,18 @@ func (o *obfuscator) writeKeyFile(path string, inputKeyFile string) (created boo
 	if err := tmp.Close(); err != nil {
 		return false, err
 	}
-	if err := os.Rename(tmp.Name(), path); err != nil {
+
+	if same {
+		if err := os.Rename(tmp.Name(), path); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if err := os.Link(tmp.Name(), path); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return false, fmt.Errorf("key file %s already exists", path)
+		}
 		return false, err
 	}
-	return !same, nil
+	return true, nil
 }

--- a/backup/obfuscate_test.go
+++ b/backup/obfuscate_test.go
@@ -141,7 +141,7 @@ func TestObfuscatorKeyFile(t *testing.T) {
 
 func TestObfuscatorMessageHeaders(t *testing.T) {
 	o, _ := newObfuscator("")
-	hdr, err := nats.DecodeHeadersMsg([]byte("NATS/1.0\r\nKV-Operation: DEL\r\nNats-Marker-Reason: MaxAge\r\nNats-TTL: 5s\r\nNats-Rollup: sub\r\nNats-Expected-Last-Subject-Sequence: 12\r\nNats-Expected-Last-Subject-Sequence-Subject: orders.new\r\nNats-Schedule: @every 1h\r\nNats-Schedule-Source: inbox.orders\r\nNats-Schedule-TTL: 5m\r\nNats-Schedule-Target: jobs.run\r\nNats-Schedule-Time-Zone: Europe/London\r\nX-Batch: seven\r\nX-Batch: eight\r\n\r\n"))
+	hdr, err := nats.DecodeHeadersMsg([]byte("NATS/1.0\r\nKV-Operation: DEL\r\nNats-Incr: +5\r\nNats-Marker-Reason: MaxAge\r\nNats-TTL: 5s\r\nNats-Rollup: sub\r\nNats-Expected-Last-Subject-Sequence: 12\r\nNats-Expected-Last-Subject-Sequence-Subject: orders.new\r\nNats-Schedule: @every 1h\r\nNats-Schedule-Source: inbox.orders\r\nNats-Schedule-TTL: 5m\r\nNats-Schedule-Target: jobs.run\r\nNats-Schedule-Time-Zone: Europe/London\r\nX-Batch: seven\r\nX-Batch: eight\r\n\r\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestObfuscatorMessageHeaders(t *testing.T) {
 	inbox, _ := o.subject("inbox.orders")
 	seven, _ := o.token("seven")
 	eight, _ := o.token("eight")
-	want := "NATS/1.0\r\nKV-Operation: DEL\r\nNats-Expected-Last-Subject-Sequence: 12\r\nNats-Expected-Last-Subject-Sequence-Subject: " + newSubj + "\r\nNats-Marker-Reason: MaxAge\r\nNats-Rollup: sub\r\nNats-Schedule: @every 1h\r\nNats-Schedule-Source: " + inbox + "\r\nNats-Schedule-TTL: 5m\r\nNats-Schedule-Target: " + jobs + "\r\nNats-Schedule-Time-Zone: Europe/London\r\nNats-TTL: 5s\r\nX-Batch: " + seven + "\r\nX-Batch: " + eight + "\r\n\r\n"
+	want := "NATS/1.0\r\nKV-Operation: DEL\r\nNats-Expected-Last-Subject-Sequence: 12\r\nNats-Expected-Last-Subject-Sequence-Subject: " + newSubj + "\r\nNats-Incr: +5\r\nNats-Marker-Reason: MaxAge\r\nNats-Rollup: sub\r\nNats-Schedule: @every 1h\r\nNats-Schedule-Source: " + inbox + "\r\nNats-Schedule-TTL: 5m\r\nNats-Schedule-Target: " + jobs + "\r\nNats-Schedule-Time-Zone: Europe/London\r\nNats-TTL: 5s\r\nX-Batch: " + seven + "\r\nX-Batch: " + eight + "\r\n\r\n"
 	if subj != newSubj || string(out) != want {
 		t.Fatalf("got\n%q\nwant\n%q", out, want)
 	}
@@ -352,6 +352,37 @@ func TestEditObfuscate(t *testing.T) {
 	body, _ = io.ReadAll(seq3.Body)
 	if !strings.Contains(string(body), "X-Batch: "+originals["batch-seven"]) {
 		t.Fatalf("header value not hashed through the table: %q", body)
+	}
+}
+
+func TestEditObfuscateCounterStream(t *testing.T) {
+	cfg := fixtureConfig()
+	cfg.AllowMsgCounter = true
+	msgs := []testMsg{
+		{"orders.count", 2, 1_000, "NATS/1.0\r\nNats-Incr: +5\r\n\r\n", `{"val":"5"}`},
+		{"orders.count", 3, 2_000, "NATS/1.0\r\nNats-Incr: +2\r\n\r\n", `{"val":"7"}`},
+	}
+	src := fixtureDirWithState(t, cfg, api.StreamState{Msgs: 2, FirstSeq: 2, LastSeq: 3, Consumers: 2}, msgs)
+
+	dst, res := edit(t, src, Obfuscate())
+	if _, err := Verify(dst); err != nil {
+		t.Fatalf("output does not verify: %v", err)
+	}
+	if res.Report.Obfuscation.BodiesDropped != 0 {
+		t.Fatalf("counter bodies must be kept: %+v", res.Report.Obfuscation)
+	}
+
+	for i, m := range messagesOf(readItems(t, dst)) {
+		body, _ := io.ReadAll(m.Body)
+		if !strings.HasSuffix(string(body), msgs[i].body) {
+			t.Fatalf("counter value lost: %q", body)
+		}
+		if !strings.Contains(string(body), "Nats-Incr: +") {
+			t.Fatalf("increment header not preserved: %q", body)
+		}
+		if strings.Contains(m.Subject, "orders") || m.PayloadSize != int64(len(msgs[i].body)) {
+			t.Fatalf("subject not hashed or payload size wrong: %+v", m)
+		}
 	}
 }
 

--- a/backup/options.go
+++ b/backup/options.go
@@ -134,7 +134,9 @@ func Renumber() EditOption {
 }
 
 // Obfuscate replaces identifying names and subjects with keyed hashes and
-// drops message bodies, writing the reverse mapping to a key file beside the target
+// drops message bodies, writing the reverse mapping to a key file beside
+// the target. On a counter stream the bodies are the running totals a
+// restored counter needs, so they are kept and the values stay readable
 func Obfuscate() EditOption {
 	return func(o *editOptions) { o.obfuscate = true }
 }

--- a/backup/verify.go
+++ b/backup/verify.go
@@ -57,7 +57,8 @@ type InfoReport struct {
 	// FirstSeq and LastSeq bound the message sequences in the archive, 0 when empty
 	FirstSeq uint64 `json:"first_seq"`
 	LastSeq  uint64 `json:"last_seq"`
-	// FirstTime and LastTime bound the message timestamps, zero when empty
+	// FirstTime and LastTime are the timestamps of the first and last message
+	// by sequence, as the server reports stream state. Zero when empty
 	FirstTime time.Time `json:"first_time"`
 	LastTime  time.Time `json:"last_time"`
 }


### PR DESCRIPTION
Creates new obfuscation key files exclusively so concurrent edits to the same target cannot delete each other's mappings.

Obfuscation now keeps counter stream bodies and no longer hashes Nats-Incr, so a restored counter stream still works while its subjects stay hidden.