### PR TITLE
(maint) Backup edit review feedback: padding, subject counts, key file lookup

### DIFF
--- a/backup/codec_test.go
+++ b/backup/codec_test.go
@@ -476,7 +476,7 @@ func TestVerifyAndInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify failed: %v", err)
 	}
-	if !rep.Complete || rep.Entries != 6 || rep.Consumers != 1 || rep.Messages != 3 || rep.FirstSeq != 2 || rep.LastSeq != 9 {
+	if !rep.Complete || rep.Entries != 6 || rep.Consumers != 1 || rep.Messages != 3 || rep.NumSubjects != 3 || rep.FirstSeq != 2 || rep.LastSeq != 9 {
 		t.Fatalf("unexpected report: %+v", rep)
 	}
 	if rep.LastGood.Kind != "end" || rep.LastGood.Ordinal != 6 {
@@ -491,8 +491,15 @@ func TestVerifyAndInfo(t *testing.T) {
 	for _, m := range msgs {
 		wantBytes += storedMsgSize(len(m.subject), int64(len(m.hdr)), int64(len(m.body)))
 	}
-	if info.Config.Name != "ORDERS" || info.Messages != 3 || info.Bytes != wantBytes || info.FirstSeq != 2 || info.LastSeq != 9 {
+	if info.Config.Name != "ORDERS" || info.Messages != 3 || info.NumSubjects != 3 || info.Subjects != nil || info.Bytes != wantBytes || info.FirstSeq != 2 || info.LastSeq != 9 {
 		t.Fatalf("unexpected info: %+v", info)
+	}
+	listed, err := Info(dir, WithSubjects())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(listed.Subjects, map[string]uint64{"orders.new": 1, "orders.paid": 1, "orders.shipped": 1}) {
+		t.Fatalf("unexpected subjects: %+v", listed.Subjects)
 	}
 	if info.FirstTime.UnixNano() != 10 || info.LastTime.UnixNano() != 30 {
 		t.Fatalf("unexpected times: %+v", info)

--- a/backup/edit.go
+++ b/backup/edit.go
@@ -74,6 +74,8 @@ func (d *DropCounts) add(kind dropKind) {
 type Report struct {
 	SourceMessages   uint64
 	Kept             uint64
+	SourceSubjects   int
+	KeptSubjects     int
 	Dropped          DropCounts
 	ConsumersKept    int
 	ConsumersDropped int
@@ -93,9 +95,9 @@ type Report struct {
 
 // ObfuscationReport describes an obfuscated edit
 type ObfuscationReport struct {
-	TokensMapped  int
-	BodiesDropped uint64
-	KeyFile       string
+	TokensMapped int
+	BodiesPadded uint64
+	KeyFile      string
 }
 
 // Edit reads the backup in srcDir, applies the options and writes a new
@@ -120,7 +122,10 @@ func Edit(ctx context.Context, srcDir string, dstDir string, opts ...EditOption)
 		return nil, fmt.Errorf("KVCompact requires a KV bucket backup: stream %q with subjects %v is not one", src.metaFile.Config.Name, src.metaFile.Config.Subjects)
 	}
 
-	ed := &editor{ctx: ctx, o: o, src: src, cfg: src.metaFile.Config, now: time.Now()}
+	ed := &editor{ctx: ctx, o: o, src: src, cfg: src.metaFile.Config, now: time.Now(), srcSubjects: newSubjectCounter()}
+	if !o.perSubject() {
+		ed.keptSubjects = newSubjectCounter()
+	}
 	if o.obfuscate {
 		if ed.obf, err = newObfuscator(o.keyFile); err != nil {
 			return nil, err
@@ -205,6 +210,13 @@ type editor struct {
 	overAge  uint64
 	digest   string
 	report   Report
+
+	// srcSubjects sees every source message; keptSubjects sees every written
+	// one on the single pass, a per-subject edit takes its kept count from
+	// Resolve instead so a dry run that stops there still reports it
+	srcSubjects      *subjectCounter
+	keptSubjects     *subjectCounter
+	keptSubjectCount int
 }
 
 func (e *editor) run(tgt *target) error {
@@ -383,6 +395,7 @@ func (e *editor) twoPass() error {
 	}
 
 	res := state.Resolve()
+	e.keptSubjectCount = int(res.subjects)
 	if e.o.kvCompact {
 		e.report.Dropped.KVCompact = passed - res.msgs
 	} else {
@@ -455,6 +468,7 @@ func (e *editor) filterMessage(m *Message) error {
 // evaluate applies the stateless filters; a rejected message is counted and reported as not ok
 func (e *editor) evaluate(m *Message) (bool, *msgBody, error) {
 	e.report.SourceMessages++
+	e.srcSubjects.add(m.Subject)
 	body := &msgBody{m: m}
 
 	kind := e.o.evalMeta(m)
@@ -521,13 +535,16 @@ func (e *editor) writeMessage(body *msgBody) error {
 			if m.PayloadSize > 0 {
 				e.obf.bodies++
 			}
-			out.Subject, out.HdrSize, out.PayloadSize, out.Body = subject, int64(len(block)), 0, bytes.NewReader(block)
+			out.Subject, out.HdrSize, out.Body = subject, int64(len(block)), io.MultiReader(bytes.NewReader(block), io.LimitReader(zeroPadding{}, m.PayloadSize))
 		}
 	} else {
 		out.Body = body.reader()
 	}
 
 	e.report.Kept++
+	if e.keptSubjects != nil {
+		e.keptSubjects.add(m.Subject)
+	}
 	if e.o.renumber {
 		out.Seq = e.report.Kept
 	}
@@ -559,6 +576,12 @@ func (e *editor) resultRange() (first uint64, last uint64) {
 }
 
 func (e *editor) result() (*Result, error) {
+	e.report.SourceSubjects = e.srcSubjects.count()
+	e.report.KeptSubjects = e.keptSubjectCount
+	if e.keptSubjects != nil {
+		e.report.KeptSubjects = e.keptSubjects.count()
+	}
+
 	cfg := e.cfg
 	if e.o.renumber {
 		cfg.FirstSeq = 0
@@ -568,7 +591,7 @@ func (e *editor) result() (*Result, error) {
 		if cfg, err = e.obf.config(cfg); err != nil {
 			return nil, err
 		}
-		e.report.Obfuscation = &ObfuscationReport{TokensMapped: len(e.obf.reverse), BodiesDropped: e.obf.bodies}
+		e.report.Obfuscation = &ObfuscationReport{TokensMapped: len(e.obf.reverse), BodiesPadded: e.obf.bodies}
 	}
 
 	st := api.StreamState{

--- a/backup/edit_test.go
+++ b/backup/edit_test.go
@@ -197,7 +197,7 @@ func TestEditIdentity(t *testing.T) {
 	}
 
 	rep := res.Report
-	if rep.SourceMessages != 7 || rep.Kept != 7 || rep.Dropped.Total() != 0 || rep.ConsumersKept != 2 || rep.ConsumersDropped != 0 || rep.TombstonesRemovedByContentFilters != 0 {
+	if rep.SourceMessages != 7 || rep.Kept != 7 || rep.SourceSubjects != 4 || rep.KeptSubjects != 4 || rep.Dropped.Total() != 0 || rep.ConsumersKept != 2 || rep.ConsumersDropped != 0 || rep.TombstonesRemovedByContentFilters != 0 {
 		t.Fatalf("unexpected report: %+v", rep)
 	}
 }
@@ -440,6 +440,9 @@ func TestEditEmptyResult(t *testing.T) {
 	}
 	if res.State.Msgs != 0 || res.State.Bytes != 0 || res.State.FirstSeq != 15 || res.State.LastSeq != 14 {
 		t.Fatalf("meta file must describe the restored empty stream at last+1/last: %+v", res.State)
+	}
+	if res.Report.SourceSubjects != 4 || res.Report.KeptSubjects != 0 {
+		t.Fatalf("unexpected subject counts %+v", res.Report)
 	}
 
 	dst, res = edit(t, src, Subjects("nothing.matches"), Renumber())

--- a/backup/obfuscate.go
+++ b/backup/obfuscate.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,7 +40,7 @@ const (
 	keyFileSuffix  = ".keys.json"
 	keyFileVersion = 1
 	secretBytes    = 32
-	tokenBytes     = 10
+	minTokenChars  = 16
 	objStorePrefix = "OBJ_"
 	kvSubjectRoot  = "$KV"
 	objSubjectRoot = "$O"
@@ -53,6 +54,45 @@ type obfuscationKeyFile struct {
 	Version int               `json:"version"`
 	Secret  string            `json:"secret"`
 	Map     map[string]string `json:"map"`
+}
+
+// KeyFile is a loaded obfuscation key file, every mapping verified against
+// its secret
+type KeyFile struct {
+	reverse map[string]string
+}
+
+// LoadKeyFile reads the key file an obfuscated edit wrote beside its target
+func LoadKeyFile(path string) (*KeyFile, error) {
+	if path == "" {
+		return nil, errors.New("key file path required")
+	}
+	o, err := newObfuscator(path)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyFile{reverse: o.reverse}, nil
+}
+
+// Reveal maps an obfuscated value back to its original: a subject token by
+// token, a KV or object store stream name behind its prefix, anything else
+// whole. Tokens the key file does not hold stay as they are
+func (k *KeyFile) Reveal(value string) string {
+	toks := strings.Split(value, ".")
+	for i, tok := range toks {
+		if orig, ok := k.reverse[tok]; ok {
+			toks[i] = orig
+			continue
+		}
+		for _, prefix := range []string{kvStreamPrefix, objStorePrefix} {
+			if rest, ok := strings.CutPrefix(tok, prefix); ok {
+				if orig, ok := k.reverse[rest]; ok {
+					toks[i] = prefix + orig
+				}
+			}
+		}
+	}
+	return strings.Join(toks, ".")
 }
 
 // obfuscator replaces identifying tokens with keyed hashes. The same secret
@@ -70,15 +110,22 @@ type obfuscationKeyFile struct {
 // every mapping against the secret, so a tampered or mismatched file is
 // rejected instead of producing conflicting tokens.
 //
-// Truncating to 10 bytes and encoding lowercase base32-hex gives a
-// 16-character token that is legal everywhere an original can appear: a
+// A token is as long as its original, with a floor of 16 characters, so the
+// obfuscated backup keeps the size profile of the source for anything at
+// least that long. Shorter originals grow to 16 rather than shrink because
+// 80 bits is where collisions stop being plausible, and token() fails on
+// one anyway instead of silently merging two originals. Past the 52
+// characters one HMAC yields, the hash is extended block by block over the
+// previous block, the token and a counter, so any length stays a pure
+// function of the secret and the original, which is what key file
+// verification recomputes.
+//
+// Lowercase base32-hex is legal everywhere an original can appear: a
 // subject token, a KV key segment, a stream or consumer name. Stream names
 // become directories in the file store, so mixed case would collide on
-// case-insensitive filesystems, and base64 uses '/' and '+'. Hex needs 20
-// characters for the same bytes, and the subject is rewritten in every
-// message record, so token length inflates the archive. A collision within
-// 80 bits needs around a trillion distinct tokens, and token() fails on one
-// anyway instead of silently merging two originals
+// case-insensitive filesystems, and base64 uses '/' and '+'. Hex would need
+// a quarter more characters for the same bits, and the subject is rewritten
+// in every message record
 type obfuscator struct {
 	secret  []byte
 	forward map[string]string
@@ -123,9 +170,21 @@ func newObfuscator(keyFile string) (*obfuscator, error) {
 }
 
 func (o *obfuscator) hash(tok string) string {
+	chars := max(minTokenChars, len(tok))
+	need := (chars*5 + 7) / 8
 	mac := hmac.New(sha256.New, o.secret)
 	mac.Write([]byte(tok))
-	return strings.ToLower(tokenEncoding.EncodeToString(mac.Sum(nil)[:tokenBytes]))
+	out := mac.Sum(nil)
+	for block := uint32(1); len(out) < need; block++ {
+		var ctr [4]byte
+		binary.BigEndian.PutUint32(ctr[:], block)
+		mac.Reset()
+		mac.Write(out[len(out)-sha256.Size:])
+		mac.Write([]byte(tok))
+		mac.Write(ctr[:])
+		out = mac.Sum(out)
+	}
+	return strings.ToLower(tokenEncoding.EncodeToString(out[:need]))[:chars]
 }
 
 func (o *obfuscator) token(tok string) (string, error) {
@@ -350,11 +409,23 @@ func (o *obfuscator) consumer(name string, data []byte) (string, []byte, error) 
 	return hashedName, out, nil
 }
 
+// zeroPadding stands in for a message body: the caller limits it to the
+// original length, so sizes survive obfuscation while the content does not
+type zeroPadding struct{}
+
+func (zeroPadding) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = '0'
+	}
+	return len(p), nil
+}
+
 // message rewrites a message's subject and headers; control headers stay
 // verbatim, subject-valued headers are token hashed and every other value
 // is hashed whole. Headers are written in key order so the output is
-// deterministic. The caller drops the body, except on counter streams
-// where the body is the running total the restored counter needs
+// deterministic. The caller replaces the body with zeroPadding, except on
+// counter streams where the body is the running total the restored counter
+// needs
 func (o *obfuscator) message(subject string, h nats.Header) (string, []byte, error) {
 	subj, err := o.subject(subject)
 	if err != nil {

--- a/backup/obfuscate_test.go
+++ b/backup/obfuscate_test.go
@@ -82,6 +82,13 @@ func TestObfuscatorTokens(t *testing.T) {
 	if must(o.token("")) != "" || must(o.subject("")) != "" {
 		t.Fatal("empty values pass through")
 	}
+	tokenChars := regexp.MustCompile(`^[0-9a-v]+$`)
+	for _, long := range []string{"ORDERS_15 29515852 > > js.in.orders_15 WVoib1Oo", strings.Repeat("k", 100)} {
+		h := must(o.token(long))
+		if len(h) != len(long) || !tokenChars.MatchString(h) || h != must(o.token(long)) {
+			t.Fatalf("long tokens must keep their length: %d chars -> %q", len(long), h)
+		}
+	}
 
 	other, _ := newObfuscator("")
 	if b, _ := other.token("orders"); a == b {
@@ -93,6 +100,7 @@ func TestObfuscatorKeyFile(t *testing.T) {
 	o, _ := newObfuscator("")
 	o.token("orders")
 	o.token("new")
+	o.token(strings.Repeat("k", 70))
 	path := filepath.Join(t.TempDir(), "k.json")
 	if created, err := o.writeKeyFile(path, ""); err != nil || !created {
 		t.Fatalf("first write: created %v err %v", created, err)
@@ -136,6 +144,40 @@ func TestObfuscatorKeyFile(t *testing.T) {
 	os.WriteFile(path, []byte(`{"version":2,"secret":"AA==","map":{}}`), 0o600)
 	if _, err := newObfuscator(path); err == nil || !strings.Contains(err.Error(), "unsupported key file version") {
 		t.Fatalf("expected a version error, got %v", err)
+	}
+}
+
+func TestLoadKeyFile(t *testing.T) {
+	src := obfuscationFixture(t)
+	dst, res := edit(t, src, Obfuscate())
+	kf, err := LoadKeyFile(res.Report.Obfuscation.KeyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadMetaFile(t, dst).Config
+	if kf.Reveal(cfg.Name) != "ORDERS" || kf.Reveal(cfg.Subjects[0]) != "orders.>" || kf.Reveal(cfg.Subjects[1]) != "audit.*" {
+		t.Fatalf("config not revealed: %q %q", kf.Reveal(cfg.Name), kf.Reveal(cfg.Subjects[0]))
+	}
+	if kf.Reveal("unknown.token") != "unknown.token" {
+		t.Fatal("unknown tokens must pass through")
+	}
+
+	o, _ := newObfuscator("")
+	bucket, _ := o.streamName("KV_bucket")
+	path := filepath.Join(t.TempDir(), "kv.keys.json")
+	if _, err := o.writeKeyFile(path, ""); err != nil {
+		t.Fatal(err)
+	}
+	kf, err = LoadKeyFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kf.Reveal(bucket) != "KV_bucket" {
+		t.Fatalf("bucket name not revealed behind its prefix: %q", kf.Reveal(bucket))
+	}
+
+	if _, err := LoadKeyFile(""); err == nil {
+		t.Fatal("an empty path must not load a fresh secret")
 	}
 }
 
@@ -275,12 +317,15 @@ func TestEditObfuscate(t *testing.T) {
 	}
 	var bytesWritten uint64
 	for _, m := range msgs {
-		if m.PayloadSize != 0 || !tokenRE.MatchString(strings.Split(m.Subject, ".")[0]) {
-			t.Fatalf("body kept or subject not hashed: %+v", m)
+		body, _ := io.ReadAll(m.Body)
+		m.Body = bytes.NewReader(body)
+		payload := body[m.HdrSize:]
+		if int64(len(payload)) != m.PayloadSize || strings.Trim(string(payload), "0") != "" || !tokenRE.MatchString(strings.Split(m.Subject, ".")[0]) {
+			t.Fatalf("body not zero padded to its length or subject not hashed: %+v", m)
 		}
 		bytesWritten += storedMsgSize(len(m.Subject), m.HdrSize, m.PayloadSize)
 	}
-	if res.Report.Obfuscation.BodiesDropped != 4 || res.State.Bytes != bytesWritten || res.State.Msgs != 6 {
+	if res.Report.Obfuscation.BodiesPadded != 4 || res.State.Bytes != bytesWritten || res.State.Msgs != 6 {
 		t.Fatalf("unexpected accounting: report %+v state %+v written %d", res.Report.Obfuscation, res.State, bytesWritten)
 	}
 	if st := items[0].(*State).State; st.Bytes != 0 || st.Consumers != 2 {
@@ -368,7 +413,7 @@ func TestEditObfuscateCounterStream(t *testing.T) {
 	if _, err := Verify(dst); err != nil {
 		t.Fatalf("output does not verify: %v", err)
 	}
-	if res.Report.Obfuscation.BodiesDropped != 0 {
+	if res.Report.Obfuscation.BodiesPadded != 0 {
 		t.Fatalf("counter bodies must be kept: %+v", res.Report.Obfuscation)
 	}
 
@@ -420,7 +465,7 @@ func TestEditObfuscateDryRunAndRefusals(t *testing.T) {
 	if entries, _ := os.ReadDir(parent); len(entries) != 0 {
 		t.Fatalf("dry run wrote files: %v", entries)
 	}
-	if dry.Report.Obfuscation == nil || dry.Report.Obfuscation.KeyFile != "" || dry.Report.Obfuscation.BodiesDropped != 4 || dry.State.Bytes == 0 {
+	if dry.Report.Obfuscation == nil || dry.Report.Obfuscation.KeyFile != "" || dry.Report.Obfuscation.BodiesPadded != 4 || dry.State.Bytes == 0 {
 		t.Fatalf("unexpected dry run result %+v %+v", dry.Report.Obfuscation, dry.State)
 	}
 

--- a/backup/options.go
+++ b/backup/options.go
@@ -134,9 +134,10 @@ func Renumber() EditOption {
 }
 
 // Obfuscate replaces identifying names and subjects with keyed hashes and
-// drops message bodies, writing the reverse mapping to a key file beside
-// the target. On a counter stream the bodies are the running totals a
-// restored counter needs, so they are kept and the values stay readable
+// message bodies with zeros of the same length, writing the reverse mapping
+// to a key file beside the target. On a counter stream the bodies are the
+// running totals a restored counter needs, so they are kept and the values
+// stay readable
 func Obfuscate() EditOption {
 	return func(o *editOptions) { o.obfuscate = true }
 }

--- a/backup/subjectstate.go
+++ b/backup/subjectstate.go
@@ -13,7 +13,29 @@
 
 package backup
 
-import "unsafe"
+import (
+	"hash/maphash"
+	"unsafe"
+)
+
+// subjectCounter counts distinct subjects through 64-bit hashes, so the
+// count costs a few bytes per subject rather than the subject itself
+type subjectCounter struct {
+	seed maphash.Seed
+	seen map[uint64]struct{}
+}
+
+func newSubjectCounter() *subjectCounter {
+	return &subjectCounter{seed: maphash.MakeSeed(), seen: map[uint64]struct{}{}}
+}
+
+func (c *subjectCounter) add(subject string) {
+	c.seen[maphash.String(c.seed, subject)] = struct{}{}
+}
+
+func (c *subjectCounter) count() int {
+	return len(c.seen)
+}
 
 // subjectState decides which messages of the filtered result survive a
 // per-subject edit. Messages are observed in ascending sequence order; after
@@ -26,11 +48,12 @@ type subjectState interface {
 	Stats() (keys uint64, bytes uint64)
 }
 
-// resolved is what a per-subject edit will write: exact message and byte
-// totals and the lowest surviving sequence
+// resolved is what a per-subject edit will write: exact message, byte and
+// subject totals and the lowest surviving sequence
 type resolved struct {
 	msgs     uint64
 	bytes    uint64
+	subjects uint64
 	firstSeq uint64
 }
 
@@ -74,6 +97,7 @@ func (s *kvCompactState) Resolve() resolved {
 	for _, slot := range s.slots {
 		if !slot.tomb {
 			res.add(slot.seq, slot.size)
+			res.subjects++
 		}
 	}
 	return res
@@ -131,6 +155,7 @@ func (s *lastPerSubjectState) Resolve() resolved {
 			res.add(e.seq, e.size)
 		}
 	}
+	res.subjects = uint64(len(s.rings))
 	return res
 }
 

--- a/backup/twopass_test.go
+++ b/backup/twopass_test.go
@@ -92,18 +92,19 @@ func TestEditLastPerSubject(t *testing.T) {
 		return total
 	}
 	cases := map[string]struct {
-		opts    []EditOption
-		seqs    []uint64
-		dropped DropCounts
-		state   api.StreamState
+		opts     []EditOption
+		seqs     []uint64
+		dropped  DropCounts
+		subjects int
+		state    api.StreamState
 	}{
-		"last 1": {[]EditOption{LastPerSubject(1)}, []uint64{6, 9, 10, 12}, DropCounts{LastPerSubject: 3},
+		"last 1": {[]EditOption{LastPerSubject(1)}, []uint64{6, 9, 10, 12}, DropCounts{LastPerSubject: 3}, 4,
 			api.StreamState{Msgs: 4, Bytes: sizeOf(6, 9, 10, 12), FirstSeq: 2, LastSeq: 14, Consumers: 2}},
-		"last 2": {[]EditOption{LastPerSubject(2)}, []uint64{3, 5, 6, 9, 10, 12}, DropCounts{LastPerSubject: 1},
+		"last 2": {[]EditOption{LastPerSubject(2)}, []uint64{3, 5, 6, 9, 10, 12}, DropCounts{LastPerSubject: 1}, 4,
 			api.StreamState{Msgs: 6, Bytes: sizeOf(3, 5, 6, 9, 10, 12), FirstSeq: 2, LastSeq: 14, Consumers: 2}},
-		"last 1 with filters": {[]EditOption{LastPerSubject(1), Subjects("orders.>"), NoHeader("Nats-TTL")}, []uint64{5, 6, 12}, DropCounts{Subject: 1, Header: 1, LastPerSubject: 2},
+		"last 1 with filters": {[]EditOption{LastPerSubject(1), Subjects("orders.>"), NoHeader("Nats-TTL")}, []uint64{5, 6, 12}, DropCounts{Subject: 1, Header: 1, LastPerSubject: 2}, 3,
 			api.StreamState{Msgs: 3, Bytes: sizeOf(5, 6, 12), FirstSeq: 2, LastSeq: 14, Consumers: 2}},
-		"last 1 renumber": {[]EditOption{LastPerSubject(1), Renumber()}, []uint64{1, 2, 3, 4}, DropCounts{LastPerSubject: 3},
+		"last 1 renumber": {[]EditOption{LastPerSubject(1), Renumber()}, []uint64{1, 2, 3, 4}, DropCounts{LastPerSubject: 3}, 4,
 			api.StreamState{Msgs: 4, Bytes: sizeOf(6, 9, 10, 12), FirstSeq: 1, LastSeq: 4}},
 	}
 
@@ -121,8 +122,8 @@ func TestEditLastPerSubject(t *testing.T) {
 			if st := items[0].(*State).State; !reflect.DeepEqual(st, tc.state) {
 				t.Fatalf("archive state %+v, want exact %+v", st, tc.state)
 			}
-			if res.Report.Dropped != tc.dropped || res.Report.Kept != uint64(len(tc.seqs)) {
-				t.Fatalf("report %+v, want dropped %+v", res.Report, tc.dropped)
+			if res.Report.Dropped != tc.dropped || res.Report.Kept != uint64(len(tc.seqs)) || res.Report.SourceSubjects != 4 || res.Report.KeptSubjects != tc.subjects {
+				t.Fatalf("report %+v, want dropped %+v and %d subjects", res.Report, tc.dropped, tc.subjects)
 			}
 			if res.Report.SubjectStateKeys == 0 || res.Report.SubjectStateBytes == 0 {
 				t.Fatalf("subject state not reported: %+v", res.Report)
@@ -157,17 +158,18 @@ func kvDir(t *testing.T, cfg api.StreamConfig) string {
 
 func TestEditKVCompact(t *testing.T) {
 	cases := map[string]struct {
-		opts    []EditOption
-		seqs    []uint64
-		dropped DropCounts
-		tombs   uint64
-		keys    uint64
+		opts     []EditOption
+		seqs     []uint64
+		dropped  DropCounts
+		tombs    uint64
+		keys     uint64
+		subjects int
 	}{
-		"compact":               {[]EditOption{KVCompact()}, []uint64{3, 8}, DropCounts{KVCompact: 7}, 0, 5},
-		"compact renumber":      {[]EditOption{KVCompact(), Renumber()}, []uint64{1, 2}, DropCounts{KVCompact: 7}, 0, 5},
-		"content filter first":  {[]EditOption{KVCompact(), NoHeader("KV-Operation")}, []uint64{2, 3, 7}, DropCounts{Header: 3, KVCompact: 3}, 2, 4},
-		"sequence filter first": {[]EditOption{KVCompact(), LastSeq(5)}, []uint64{3, 5}, DropCounts{Sequence: 4, KVCompact: 3}, 0, 3},
-		"subject filter first":  {[]EditOption{KVCompact(), Subjects("$KV.orders.b", "$KV.orders.d")}, []uint64{8}, DropCounts{Subject: 5, KVCompact: 3}, 0, 2},
+		"compact":               {[]EditOption{KVCompact()}, []uint64{3, 8}, DropCounts{KVCompact: 7}, 0, 5, 2},
+		"compact renumber":      {[]EditOption{KVCompact(), Renumber()}, []uint64{1, 2}, DropCounts{KVCompact: 7}, 0, 5, 2},
+		"content filter first":  {[]EditOption{KVCompact(), NoHeader("KV-Operation")}, []uint64{2, 3, 7}, DropCounts{Header: 3, KVCompact: 3}, 2, 4, 3},
+		"sequence filter first": {[]EditOption{KVCompact(), LastSeq(5)}, []uint64{3, 5}, DropCounts{Sequence: 4, KVCompact: 3}, 0, 3, 2},
+		"subject filter first":  {[]EditOption{KVCompact(), Subjects("$KV.orders.b", "$KV.orders.d")}, []uint64{8}, DropCounts{Subject: 5, KVCompact: 3}, 0, 2, 1},
 	}
 
 	for name, tc := range cases {
@@ -180,8 +182,8 @@ func TestEditKVCompact(t *testing.T) {
 			if got := seqsOf(messagesOf(readItems(t, dst))); !reflect.DeepEqual(got, tc.seqs) {
 				t.Fatalf("kept %v, want %v", got, tc.seqs)
 			}
-			if res.Report.Dropped != tc.dropped || res.Report.TombstonesRemovedByContentFilters != tc.tombs || res.Report.SubjectStateKeys != tc.keys {
-				t.Fatalf("report %+v", res.Report)
+			if res.Report.Dropped != tc.dropped || res.Report.TombstonesRemovedByContentFilters != tc.tombs || res.Report.SubjectStateKeys != tc.keys || res.Report.SourceSubjects != 5 || res.Report.KeptSubjects != tc.subjects {
+				t.Fatalf("report %+v, want %d kept subjects", res.Report, tc.subjects)
 			}
 		})
 	}

--- a/backup/verify.go
+++ b/backup/verify.go
@@ -24,9 +24,10 @@ import (
 // VerifyReport summarizes a scan of a backup directory
 type VerifyReport struct {
 	// Entries is the number of archive entries that decoded cleanly
-	Entries   int
-	Consumers int
-	Messages  uint64
+	Entries     int
+	Consumers   int
+	Messages    uint64
+	NumSubjects int
 	// FirstSeq and LastSeq are the first and last message sequences found, 0 when empty
 	FirstSeq uint64
 	LastSeq  uint64
@@ -52,6 +53,11 @@ type InfoReport struct {
 	Consumers []string `json:"consumers"`
 	// Messages is the number of messages in the archive
 	Messages uint64 `json:"messages"`
+	// NumSubjects is the number of distinct subjects in the archive
+	NumSubjects int `json:"num_subjects"`
+	// Subjects maps every subject in the archive to its message count, only
+	// when Info was called with WithSubjects
+	Subjects map[string]uint64 `json:"subjects,omitempty"`
 	// Bytes is the storage the messages will occupy on restore, per the file store's accounting
 	Bytes uint64 `json:"bytes"`
 	// FirstSeq and LastSeq bound the message sequences in the archive, 0 when empty
@@ -69,17 +75,34 @@ type InfoReport struct {
 // valid; when the archive fails part way the report and the error name the
 // last good entry
 func Verify(dir string) (*VerifyReport, error) {
-	_, report, err := scan(dir)
+	_, report, err := scan(dir, false)
 	return report, err
 }
 
+// InfoOption configures Info
+type InfoOption func(*infoOptions)
+
+type infoOptions struct {
+	subjects bool
+}
+
+// WithSubjects collects every subject in the archive with its message
+// count, which holds each subject in memory once
+func WithSubjects() InfoOption {
+	return func(o *infoOptions) { o.subjects = true }
+}
+
 // Info scans a backup directory to the sentinel and reports what it holds
-func Info(dir string) (*InfoReport, error) {
-	info, _, err := scan(dir)
+func Info(dir string, opts ...InfoOption) (*InfoReport, error) {
+	o := &infoOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	info, _, err := scan(dir, o.subjects)
 	return info, err
 }
 
-func scan(dir string) (*InfoReport, *VerifyReport, error) {
+func scan(dir string, withSubjects bool) (*InfoReport, *VerifyReport, error) {
 	data, meta, err := backupPaths(dir)
 	if err != nil {
 		return nil, nil, err
@@ -97,7 +120,11 @@ func scan(dir string) (*InfoReport, *VerifyReport, error) {
 	defer f.Close()
 
 	info := &InfoReport{Config: mf.Config, Edit: mf.Edit}
+	if withSubjects {
+		info.Subjects = map[string]uint64{}
+	}
 	report := &VerifyReport{}
+	subjects := newSubjectCounter()
 	dec := NewDecoder(f)
 	for {
 		item, err := dec.Next()
@@ -105,6 +132,7 @@ func scan(dir string) (*InfoReport, *VerifyReport, error) {
 			report.LastGood = dec.LastGood()
 			report.FirstSeq = info.FirstSeq
 			report.LastSeq = info.LastSeq
+			report.NumSubjects = subjects.count()
 			return nil, report, fmt.Errorf("%s: %w (last good entry: %s)", data, err, report.LastGood)
 		}
 
@@ -118,6 +146,10 @@ func scan(dir string) (*InfoReport, *VerifyReport, error) {
 		case *Message:
 			info.Messages++
 			report.Messages++
+			subjects.add(it.Subject)
+			if info.Subjects != nil {
+				info.Subjects[it.Subject]++
+			}
 			info.Bytes += storedMsgSize(len(it.Subject), it.HdrSize, it.PayloadSize)
 			if info.FirstSeq == 0 {
 				info.FirstSeq = it.Seq
@@ -130,6 +162,8 @@ func scan(dir string) (*InfoReport, *VerifyReport, error) {
 			report.LastGood = dec.LastGood()
 			report.FirstSeq = info.FirstSeq
 			report.LastSeq = info.LastSeq
+			report.NumSubjects = subjects.count()
+			info.NumSubjects = report.NumSubjects
 			info.DeclaredCountsAdvisory = info.Messages > 0 && (info.Declared.Msgs == 0 || info.Declared.Bytes == 0)
 			return info, report, nil
 		}

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -87,7 +87,7 @@ func TestBackupVerifyAndInfoOnServerSnapshot(t *testing.T) {
 
 		rep, err := backup.Verify(dir)
 		checkErr(t, err, "verify failed")
-		if !rep.Complete || rep.Entries != 22 || rep.Consumers != 2 || rep.Messages != state.Msgs || rep.FirstSeq != state.FirstSeq || rep.LastSeq != state.LastSeq {
+		if !rep.Complete || rep.Entries != 22 || rep.Consumers != 2 || rep.Messages != state.Msgs || rep.NumSubjects != state.NumSubjects || rep.FirstSeq != state.FirstSeq || rep.LastSeq != state.LastSeq {
 			t.Fatalf("unexpected report: %+v vs state %+v", rep, state)
 		}
 
@@ -96,7 +96,7 @@ func TestBackupVerifyAndInfoOnServerSnapshot(t *testing.T) {
 		if info.Config.Name != "ORDERS" || !reflect.DeepEqual(info.Config.Subjects, []string{"orders.>"}) {
 			t.Fatalf("unexpected config: %+v", info.Config)
 		}
-		if info.Messages != state.Msgs || info.FirstSeq != state.FirstSeq || info.LastSeq != state.LastSeq {
+		if info.Messages != state.Msgs || info.NumSubjects != state.NumSubjects || info.FirstSeq != state.FirstSeq || info.LastSeq != state.LastSeq {
 			t.Fatalf("unexpected counts: %+v vs %+v", info, state)
 		}
 		if info.Bytes != state.Bytes {
@@ -542,7 +542,7 @@ func TestBackupEditObfuscateRestores(t *testing.T) {
 
 		msg, err := stream.ReadMessage(2)
 		checkErr(t, err, "read failed")
-		if len(msg.Data) != 0 || msg.Subject != originals["orders"]+"."+originals["paid"] {
+		if string(msg.Data) != "000000" || msg.Subject != originals["orders"]+"."+originals["paid"] {
 			t.Fatalf("message not obfuscated: %+v", msg)
 		}
 		hdr, err := nats.DecodeHeadersMsg(msg.Header)
@@ -575,8 +575,8 @@ func TestBackupEditObfuscateKVRestores(t *testing.T) {
 		for _, key := range []string{"a", "d", "f"} {
 			entry, err := kv.Get(ctx, originals[key])
 			checkErr(t, err, "get "+key+" failed")
-			if len(entry.Value()) != 0 {
-				t.Fatalf("value of %s survived obfuscation: %q", key, entry.Value())
+			if string(entry.Value()) != "00" {
+				t.Fatalf("value of %s not zero padded to its length: %q", key, entry.Value())
 			}
 		}
 		keys, err := kv.Keys(ctx)


### PR DESCRIPTION
Obfuscation now replaces message bodies with zeros of the same length instead of dropping them, and a hashed token is as long as its original with a floor of 16 characters, so an obfuscated backup keeps the size profile of its source.

Verify, Info and the edit Report count distinct subjects and Info lists every subject with its message count under WithSubjects.

LoadKeyFile with Reveal maps obfuscated values back through a key file.