### PR TITLE
Update api post structure changes

### DIFF
--- a/api/event/event.go
+++ b/api/event/event.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"fmt"
+	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -138,16 +139,18 @@ type stringer interface {
 
 func compileTemplate(schema string, body string) (*template.Template, error) {
 	return template.New(schema).Funcs(map[string]any{
-		"ShortTime":   func(v time.Time) string { return v.Format("15:04:05") },
-		"NanoTime":    func(v time.Time) string { return v.Format("15:04:05.000") },
-		"IBytes":      func(v int64) string { return humanize.IBytes(uint64(v)) },
-		"IntCommas":   func(v int) string { return humanize.Comma(int64(v)) },
-		"Int64Commas": func(v int64) string { return humanize.Comma(v) },
-		"HostPort":    func(h string, p int) string { return net.JoinHostPort(h, strconv.Itoa(p)) },
-		"LeftPad":     func(indent int, v string) string { return leftPad(v, indent) },
-		"ToString":    func(v stringer) string { return v.String() },
-		"TitleString": func(v string) string { return cases.Title(language.AmericanEnglish).String(v) },
-		"JoinStrings": func(v []string) string { return strings.Join(v, ",") },
+		"ShortTime":    func(v time.Time) string { return v.Format("15:04:05") },
+		"NanoTime":     func(v time.Time) string { return v.Format("15:04:05.000") },
+		"IBytes":       func(v int64) string { return humanize.IBytes(uint64(v)) },
+		"IntCommas":    func(v int) string { return humanize.Comma(int64(v)) },
+		"Int64Commas":  func(v int64) string { return humanize.Comma(v) },
+		"Uint64Commas": func(v uint64) string { return humanize.BigComma(new(big.Int).SetUint64(v)) },
+		"Uint64IBytes": func(v uint64) string { return humanize.IBytes(v) },
+		"HostPort":     func(h string, p int) string { return net.JoinHostPort(h, strconv.Itoa(p)) },
+		"LeftPad":      func(indent int, v string) string { return leftPad(v, indent) },
+		"ToString":     func(v stringer) string { return v.String() },
+		"TitleString":  func(v string) string { return cases.Title(language.AmericanEnglish).String(v) },
+		"JoinStrings":  func(v []string) string { return strings.Join(v, ",") },
 	}).Parse(body)
 }
 

--- a/api/jetstream/advisory/api_audit.go
+++ b/api/jetstream/advisory/api_audit.go
@@ -16,6 +16,7 @@ type JetStreamAPIAuditV1 struct {
 	Subject  string                `json:"subject"`
 	Request  string                `json:"request,omitempty"`
 	Response string                `json:"response"`
+	Domain   string                `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/consumer_action.go
+++ b/api/jetstream/advisory/consumer_action.go
@@ -13,6 +13,7 @@ type JSConsumerActionAdvisoryV1 struct {
 	Stream   string               `json:"stream"`
 	Consumer string               `json:"consumer"`
 	Action   ActionAdvisoryTypeV1 `json:"action"`
+	Domain   string               `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/consumer_leader_elected.go
+++ b/api/jetstream/advisory/consumer_leader_elected.go
@@ -14,6 +14,8 @@ type JSConsumerLeaderElectedV1 struct {
 	Consumer string        `json:"consumer"`
 	Leader   string        `json:"leader"`
 	Replicas []*PeerInfoV1 `json:"replicas"`
+	Account  string        `json:"account,omitempty"`
+	Domain   string        `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/cosumer_quorum_lost.go
+++ b/api/jetstream/advisory/cosumer_quorum_lost.go
@@ -13,6 +13,8 @@ type JSConsumerQuorumLostV1 struct {
 	Stream   string        `json:"stream"`
 	Consumer string        `json:"consumer"`
 	Replicas []*PeerInfoV1 `json:"replicas"`
+	Account  string        `json:"account,omitempty"`
+	Domain   string        `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/max_deliver.go
+++ b/api/jetstream/advisory/max_deliver.go
@@ -15,6 +15,7 @@ type ConsumerDeliveryExceededAdvisoryV1 struct {
 	Consumer   string `json:"consumer"`
 	StreamSeq  uint64 `json:"stream_seq"`
 	Deliveries uint64 `json:"deliveries"`
+	Domain     string `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/restore_complete.go
+++ b/api/jetstream/advisory/restore_complete.go
@@ -18,6 +18,7 @@ type JSRestoreCompleteAdvisoryV1 struct {
 	End    time.Time             `json:"end"`
 	Bytes  int64                 `json:"bytes"`
 	Client advisory.ClientInfoV1 `json:"client"`
+	Domain string                `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/restore_create.go
+++ b/api/jetstream/advisory/restore_create.go
@@ -13,6 +13,7 @@ type JSRestoreCreateAdvisoryV1 struct {
 
 	Stream string                `json:"stream"`
 	Client advisory.ClientInfoV1 `json:"client"`
+	Domain string                `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/server_out_of_space.go
+++ b/api/jetstream/advisory/server_out_of_space.go
@@ -14,6 +14,7 @@ type JSServerOutOfSpaceAdvisoryV1 struct {
 	ServerID string `json:"server_id"`
 	Stream   string `json:"stream,omitempty"`
 	Cluster  string `json:"cluster"`
+	Domain   string `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/snapshot_complete.go
+++ b/api/jetstream/advisory/snapshot_complete.go
@@ -17,6 +17,8 @@ type JSSnapshotCompleteAdvisoryV1 struct {
 	Start  time.Time             `json:"start"`
 	End    time.Time             `json:"end"`
 	Client advisory.ClientInfoV1 `json:"client"`
+	Domain string                `json:"domain,omitempty"`
+	Error  string                `json:"error,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/snapshot_complete.go
+++ b/api/jetstream/advisory/snapshot_complete.go
@@ -22,17 +22,20 @@ type JSSnapshotCompleteAdvisoryV1 struct {
 }
 
 func init() {
-	err := event.RegisterTextCompactTemplate("io.nats.jetstream.advisory.v1.snapshot_complete", `{{ .Time | ShortTime }} [Snapshot Complete] {{ .Stream }} started {{ .Start | ShortTime }} ended {{ .End | ShortTime }}`)
+	err := event.RegisterTextCompactTemplate("io.nats.jetstream.advisory.v1.snapshot_complete", `{{ .Time | ShortTime }} [Snapshot {{ if .Error }}Failed{{ else }}Complete{{ end }}] {{ .Stream }} started {{ .Start | ShortTime }} ended {{ .End | ShortTime }}{{ if .Error }}: {{ .Error }}{{ end }}`)
 	if err != nil {
 		panic(err)
 	}
 
 	err = event.RegisterTextExtendedTemplate("io.nats.jetstream.advisory.v1.snapshot_complete", `
-[{{ .Time | ShortTime }}] [{{ .ID }}] Stream Snapshot Completed
+[{{ .Time | ShortTime }}] [{{ .ID }}] Stream Snapshot {{ if .Error }}Failed{{ else }}Completed{{ end }}
 
         Stream: {{ .Stream }}
-		Start: {{ .Start | NanoTime }}
-          End: {{ .End | NanoTime }}
+{{- if .Error }}
+         Error: {{ .Error }}
+{{- end }}
+         Start: {{ .Start | NanoTime }}
+           End: {{ .End | NanoTime }}
         Client:
 {{- if .Client.User }}
                      User: {{ .Client.User }} Account: {{ .Client.Account }}

--- a/api/jetstream/advisory/snapshot_create.go
+++ b/api/jetstream/advisory/snapshot_create.go
@@ -1,6 +1,7 @@
 package advisory
 
 import (
+	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/jsm.go/api/event"
 	"github.com/nats-io/jsm.go/api/server/advisory"
 )
@@ -14,6 +15,8 @@ type JSSnapshotCreateAdvisoryV1 struct {
 	NumBlks int64                 `json:"blocks"`
 	BlkSize int64                 `json:"block_size"`
 	Client  advisory.ClientInfoV1 `json:"client"`
+	State   api.StreamState       `json:"state"`
+	Domain  string                `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/snapshot_create.go
+++ b/api/jetstream/advisory/snapshot_create.go
@@ -11,16 +11,14 @@ import (
 // NATS Schema io.nats.jetstream.advisory.v1.snapshot_create
 type JSSnapshotCreateAdvisoryV1 struct {
 	event.NATSEvent
-	Stream  string                `json:"stream"`
-	NumBlks int64                 `json:"blocks"`
-	BlkSize int64                 `json:"block_size"`
-	Client  advisory.ClientInfoV1 `json:"client"`
-	State   api.StreamState       `json:"state"`
-	Domain  string                `json:"domain,omitempty"`
+	Stream string                `json:"stream"`
+	Client advisory.ClientInfoV1 `json:"client"`
+	State  api.StreamState       `json:"state"`
+	Domain string                `json:"domain,omitempty"`
 }
 
 func init() {
-	err := event.RegisterTextCompactTemplate("io.nats.jetstream.advisory.v1.snapshot_create", `{{ .Time | ShortTime }} [Snapshot Create] {{ .Stream }} {{ .NumBlks | Int64Commas }} blocks of {{ .BlkSize | IBytes }}`)
+	err := event.RegisterTextCompactTemplate("io.nats.jetstream.advisory.v1.snapshot_create", `{{ .Time | ShortTime }} [Snapshot Create] {{ .Stream }} {{ .State.Msgs | Uint64Commas }} messages {{ .State.Bytes | Uint64IBytes }}`)
 	if err != nil {
 		panic(err)
 	}
@@ -29,8 +27,9 @@ func init() {
 [{{ .Time | ShortTime }}] [{{ .ID }}] Stream Snapshot Created
 
         Stream: {{ .Stream }}
-        Blocks: {{ .NumBlks | Int64Commas }}
-    Block Size: {{ .BlkSize | IBytes }}
+      Messages: {{ .State.Msgs | Uint64Commas }}
+         Bytes: {{ .State.Bytes | Uint64IBytes }}
+     Sequences: {{ .State.FirstSeq | Uint64Commas }} - {{ .State.LastSeq | Uint64Commas }}
         Client:
 {{- if .Client.User }}
                       User: {{ .Client.User }} Account: {{ .Client.Account }}

--- a/api/jetstream/advisory/stream_action.go
+++ b/api/jetstream/advisory/stream_action.go
@@ -26,6 +26,7 @@ type JSStreamActionAdvisoryV1 struct {
 	Stream   string               `json:"stream"`
 	Action   ActionAdvisoryTypeV1 `json:"action"`
 	Template string               `json:"template,omitempty"`
+	Domain   string               `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/stream_action.go
+++ b/api/jetstream/advisory/stream_action.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nats-io/jsm.go/api/event"
 )
 
-// ActionAdvisoryTypeV1 indicates which action against a stream, consumer or template triggered an advisory
+// ActionAdvisoryTypeV1 indicates which action against a stream or consumer triggered an advisory
 type ActionAdvisoryTypeV1 string
 
 func (a ActionAdvisoryTypeV1) String() string {
@@ -23,10 +23,9 @@ const (
 type JSStreamActionAdvisoryV1 struct {
 	event.NATSEvent
 
-	Stream   string               `json:"stream"`
-	Action   ActionAdvisoryTypeV1 `json:"action"`
-	Template string               `json:"template,omitempty"`
-	Domain   string               `json:"domain,omitempty"`
+	Stream string               `json:"stream"`
+	Action ActionAdvisoryTypeV1 `json:"action"`
+	Domain string               `json:"domain,omitempty"`
 }
 
 func init() {
@@ -38,10 +37,7 @@ func init() {
 	err = event.RegisterTextExtendedTemplate("io.nats.jetstream.advisory.v1.stream_action", `
 [{{ .Time | ShortTime }}] [{{ .ID }}] Stream {{ .Action | ToString | TitleString }} Action
 
-        Stream: {{ .Stream }}
-{{- if .Template }}
-      Template: {{ .Template }}
-{{- end }}`)
+        Stream: {{ .Stream }}`)
 	if err != nil {
 		panic(err)
 	}

--- a/api/jetstream/advisory/stream_leader_elected.go
+++ b/api/jetstream/advisory/stream_leader_elected.go
@@ -1,17 +1,12 @@
 package advisory
 
 import (
-	"time"
-
+	"github.com/nats-io/jsm.go/api"
 	"github.com/nats-io/jsm.go/api/event"
 )
 
 // PeerInfoV1 is information about a specific peer in a cluster
-type PeerInfoV1 struct {
-	Name    string        `json:"name"`
-	Current bool          `json:"current"`
-	Active  time.Duration `json:"active"`
-}
+type PeerInfoV1 = api.PeerInfo
 
 // JSStreamLeaderElectedV1 is a advisory published when a stream elects a new leader
 //
@@ -22,6 +17,8 @@ type JSStreamLeaderElectedV1 struct {
 	Stream   string        `json:"stream"`
 	Leader   string        `json:"leader"`
 	Replicas []*PeerInfoV1 `json:"replicas"`
+	Account  string        `json:"account,omitempty"`
+	Domain   string        `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/advisory/stream_quorum_lost.go
+++ b/api/jetstream/advisory/stream_quorum_lost.go
@@ -12,6 +12,8 @@ type JSStreamQuorumLostV1 struct {
 
 	Stream   string        `json:"stream"`
 	Replicas []*PeerInfoV1 `json:"replicas"`
+	Account  string        `json:"account,omitempty"`
+	Domain   string        `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/jetstream/metric/consumer_ack.go
+++ b/api/jetstream/metric/consumer_ack.go
@@ -17,6 +17,7 @@ type ConsumerAckMetricV1 struct {
 	StreamSeq   uint64 `json:"stream_seq"`
 	Delay       int64  `json:"ack_time"`
 	Deliveries  uint64 `json:"deliveries"`
+	Domain      string `json:"domain,omitempty"`
 }
 
 func init() {

--- a/api/server/advisory/account_connections.go
+++ b/api/server/advisory/account_connections.go
@@ -19,6 +19,8 @@ type AccountConnectionsV1 struct {
 	Sent          DataStatsV1  `json:"sent"`
 	Received      DataStatsV1  `json:"received"`
 	SlowConsumers int64        `json:"slow_consumers"`
+	Name          string       `json:"name"`
+	NumSubs       uint32       `json:"num_subscriptions"`
 }
 
 func init() {

--- a/api/server/advisory/misc.go
+++ b/api/server/advisory/misc.go
@@ -4,18 +4,19 @@ import "time"
 
 // ServerInfoV1 identifies remote servers.
 type ServerInfoV1 struct {
-	Name      string            `json:"name"`
-	Host      string            `json:"host"`
-	ID        string            `json:"id"`
-	Cluster   string            `json:"cluster,omitempty"`
-	Domain    string            `json:"domain,omitempty"`
-	Version   string            `json:"ver"`
-	Tags      []string          `json:"tags,omitempty"`
-	Metadata  map[string]string `json:"metadata,omitempty"`
-	JetStream bool              `json:"jetstream"` // Whether JetStream is enabled (deprecated in favor of the `ServerCapability`).
-	Flags     uint64            `json:"flags"`     // Generic capability flags
-	Seq       uint64            `json:"seq"`       // Sequence and Time from the remote server for this message.
-	Time      time.Time         `json:"time"`
+	Name         string            `json:"name"`
+	Host         string            `json:"host"`
+	ID           string            `json:"id"`
+	Cluster      string            `json:"cluster,omitempty"`
+	Domain       string            `json:"domain,omitempty"`
+	Version      string            `json:"ver"`
+	Tags         []string          `json:"tags,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	JetStream    bool              `json:"jetstream"` // Whether JetStream is enabled (deprecated in favor of the `ServerCapability`).
+	Flags        uint64            `json:"flags"`     // Generic capability flags
+	Seq          uint64            `json:"seq"`       // Sequence and Time from the remote server for this message.
+	Time         time.Time         `json:"time"`
+	FeatureFlags map[string]bool   `json:"feature_flags,omitempty"`
 }
 
 // ClientInfoV1 is detailed information about the client forming a connection.
@@ -42,6 +43,7 @@ type ClientInfoV1 struct {
 	ClientType string        `json:"client_type,omitempty"`
 	MQTTClient string        `json:"client_id,omitempty"` // This is the MQTT client ID
 	Nonce      string        `json:"nonce,omitempty"`
+	Reply      string        `json:"reply,omitempty"`
 }
 
 // DataStatsV1 reports how may msg and bytes. Applicable for both sent and received.

--- a/schema_source/definitions.json
+++ b/schema_source/definitions.json
@@ -107,6 +107,10 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
     }

--- a/schema_source/jetstream/advisory/v1/api_audit.json
+++ b/schema_source/jetstream/advisory/v1/api_audit.json
@@ -47,6 +47,10 @@
     },
     "client": {
       "$ref": "../../../definitions.json#/definitions/client_info_v1"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/consumer_action.json
+++ b/schema_source/jetstream/advisory/v1/consumer_action.json
@@ -37,6 +37,10 @@
     "consumer": {
       "type": "string",
       "description": "The name of the Consumer that's acted on"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/consumer_leader_elected.json
+++ b/schema_source/jetstream/advisory/v1/consumer_leader_elected.json
@@ -40,7 +40,18 @@
       "description": "The server name of the elected leader"
     },
     "replicas": {
-      "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      "type": "array",
+      "items": {
+        "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/consumer_quorum_lost.json
+++ b/schema_source/jetstream/advisory/v1/consumer_quorum_lost.json
@@ -35,7 +35,18 @@
       "description": "The name of the Consumer that lost quorum"
     },
     "replicas": {
-      "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      "type": "array",
+      "items": {
+        "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/max_deliver.json
+++ b/schema_source/jetstream/advisory/v1/max_deliver.json
@@ -45,6 +45,10 @@
       "type": "integer",
       "minimum": 1,
       "description": "The number of deliveries that were attempted"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/restore_complete.json
+++ b/schema_source/jetstream/advisory/v1/restore_complete.json
@@ -47,6 +47,10 @@
     },
     "client": {
       "$ref": "../../../definitions.json#/definitions/client_info_v1"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/restore_create.json
+++ b/schema_source/jetstream/advisory/v1/restore_create.json
@@ -31,6 +31,10 @@
     },
     "client": {
       "$ref": "../../../definitions.json#/definitions/client_info_v1"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/server_out_of_space.json
+++ b/schema_source/jetstream/advisory/v1/server_out_of_space.json
@@ -40,6 +40,10 @@
     "cluster": {
       "type": "string",
       "description": "The cluster the server is in"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/snapshot_complete.json
+++ b/schema_source/jetstream/advisory/v1/snapshot_complete.json
@@ -41,6 +41,14 @@
     },
     "client": {
       "$ref": "../../../definitions.json#/definitions/client_info_v1"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
+    },
+    "error": {
+      "type": "string",
+      "description": "The error that caused the snapshot to fail, when set the snapshot did not complete"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/snapshot_create.json
+++ b/schema_source/jetstream/advisory/v1/snapshot_create.json
@@ -43,6 +43,14 @@
     },
     "client": {
       "$ref": "../../../definitions.json#/definitions/client_info_v1"
+    },
+    "state": {
+      "description": "The state of the Stream at the time the snapshot was started",
+      "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/stream_state"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/snapshot_create.json
+++ b/schema_source/jetstream/advisory/v1/snapshot_create.json
@@ -9,9 +9,8 @@
     "id",
     "timestamp",
     "stream",
-    "blocks",
-    "block_size",
-    "client"
+    "client",
+    "state"
   ],
   "additionalProperties": false,
   "properties": {
@@ -30,16 +29,6 @@
     "stream": {
       "type": "string",
       "description": "The name of the Stream being snapshotted"
-    },
-    "blocks": {
-      "type": "integer",
-      "description": "Approximate number of blocks in the snapshot",
-      "minimum": 0
-    },
-    "block_size": {
-      "type": "integer",
-      "description": "The size, in bytes, of every block",
-      "minimum": 1
     },
     "client": {
       "$ref": "../../../definitions.json#/definitions/client_info_v1"

--- a/schema_source/jetstream/advisory/v1/stream_action.json
+++ b/schema_source/jetstream/advisory/v1/stream_action.json
@@ -37,6 +37,10 @@
     "template": {
       "type": "string",
       "description": "The Stream Template that manages the Stream"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/stream_action.json
+++ b/schema_source/jetstream/advisory/v1/stream_action.json
@@ -34,10 +34,6 @@
       "type": "string",
       "description": "The name of the Stream that's acted on"
     },
-    "template": {
-      "type": "string",
-      "description": "The Stream Template that manages the Stream"
-    },
     "domain": {
       "type": "string",
       "description": "The domain of the JetStream server the event is from"

--- a/schema_source/jetstream/advisory/v1/stream_leader_elected.json
+++ b/schema_source/jetstream/advisory/v1/stream_leader_elected.json
@@ -35,7 +35,18 @@
       "description": "The server name of the elected leader"
     },
     "replicas": {
-      "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      "type": "array",
+      "items": {
+        "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/advisory/v1/stream_quorum_lost.json
+++ b/schema_source/jetstream/advisory/v1/stream_quorum_lost.json
@@ -30,7 +30,18 @@
       "description": "The name of the Stream that lost quorum"
     },
     "replicas": {
-      "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      "type": "array",
+      "items": {
+        "$ref": "../../../jetstream/api/v1/definitions.json#/definitions/peer_info"
+      }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/jetstream/metric/v1/consumer_ack.json
+++ b/schema_source/jetstream/metric/v1/consumer_ack.json
@@ -57,6 +57,10 @@
       "type": "integer",
       "minimum": 1,
       "description": "The number of deliveries that were attempted before being acknowledged"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schema_source/server/advisory/v1/account_connections.json
+++ b/schema_source/server/advisory/v1/account_connections.json
@@ -62,6 +62,15 @@
       "type": "integer",
       "description": "The number of slow consumer errors this account encountered",
       "minimum": 0
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the account"
+    },
+    "num_subscriptions": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The number of subscriptions the account has"
     }
   }
 }

--- a/schema_source/server/advisory/v1/definitions.json
+++ b/schema_source/server/advisory/v1/definitions.json
@@ -88,6 +88,13 @@
           "type": "object",
           "description": "The metadata assigned to the server"
         },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags the server has enabled",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
         "seq": {
           "type": "integer",
           "description": "Internal server sequence ID"

--- a/schemas/jetstream/advisory/v1/api_audit.json
+++ b/schemas/jetstream/advisory/v1/api_audit.json
@@ -146,8 +146,16 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/consumer_action.json
+++ b/schemas/jetstream/advisory/v1/consumer_action.json
@@ -40,6 +40,10 @@
     "consumer": {
       "type": "string",
       "description": "The name of the Consumer that's acted on"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/consumer_leader_elected.json
+++ b/schemas/jetstream/advisory/v1/consumer_leader_elected.json
@@ -40,52 +40,63 @@
       "description": "The server name of the elected leader"
     },
     "replicas": {
-      "type": "object",
-      "required": [
-        "name",
-        "current",
-        "active"
-      ],
-      "properties": {
-        "name": {
-          "description": "The server name of the peer",
-          "type": "string",
-          "minLength": 1
-        },
-        "current": {
-          "description": "Indicates if the server is up to date and synchronised",
-          "type": "boolean",
-          "default": false
-        },
-        "active": {
-          "description": "Nanoseconds since this peer was last seen",
-          "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
-          "minimum": 0,
-          "type": "integer",
-          "maximum": 9223372036854775807
-        },
-        "offline": {
-          "description": "Indicates the node is considered offline by the group",
-          "type": "boolean",
-          "default": false
-        },
-        "lag": {
-          "description": "How many uncommitted operations this peer is behind the leader",
-          "$comment": "unsigned 64 bit integer",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615
-        },
-        "peer": {
-          "description": "The unique ID for the peer",
-          "type": "string"
-        },
-        "pending": {
-          "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
-          "type": "boolean",
-          "default": false
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "current",
+          "active"
+        ],
+        "properties": {
+          "name": {
+            "description": "The server name of the peer",
+            "type": "string",
+            "minLength": 1
+          },
+          "current": {
+            "description": "Indicates if the server is up to date and synchronised",
+            "type": "boolean",
+            "default": false
+          },
+          "active": {
+            "description": "Nanoseconds since this peer was last seen",
+            "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
+            "minimum": 0,
+            "type": "integer",
+            "maximum": 9223372036854775807
+          },
+          "offline": {
+            "description": "Indicates the node is considered offline by the group",
+            "type": "boolean",
+            "default": false
+          },
+          "lag": {
+            "description": "How many uncommitted operations this peer is behind the leader",
+            "$comment": "unsigned 64 bit integer",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "peer": {
+            "description": "The unique ID for the peer",
+            "type": "string"
+          },
+          "pending": {
+            "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
+            "type": "boolean",
+            "default": false
+          }
         }
       }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/consumer_quorum_lost.json
+++ b/schemas/jetstream/advisory/v1/consumer_quorum_lost.json
@@ -35,52 +35,63 @@
       "description": "The name of the Consumer that lost quorum"
     },
     "replicas": {
-      "type": "object",
-      "required": [
-        "name",
-        "current",
-        "active"
-      ],
-      "properties": {
-        "name": {
-          "description": "The server name of the peer",
-          "type": "string",
-          "minLength": 1
-        },
-        "current": {
-          "description": "Indicates if the server is up to date and synchronised",
-          "type": "boolean",
-          "default": false
-        },
-        "active": {
-          "description": "Nanoseconds since this peer was last seen",
-          "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
-          "minimum": 0,
-          "type": "integer",
-          "maximum": 9223372036854775807
-        },
-        "offline": {
-          "description": "Indicates the node is considered offline by the group",
-          "type": "boolean",
-          "default": false
-        },
-        "lag": {
-          "description": "How many uncommitted operations this peer is behind the leader",
-          "$comment": "unsigned 64 bit integer",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615
-        },
-        "peer": {
-          "description": "The unique ID for the peer",
-          "type": "string"
-        },
-        "pending": {
-          "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
-          "type": "boolean",
-          "default": false
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "current",
+          "active"
+        ],
+        "properties": {
+          "name": {
+            "description": "The server name of the peer",
+            "type": "string",
+            "minLength": 1
+          },
+          "current": {
+            "description": "Indicates if the server is up to date and synchronised",
+            "type": "boolean",
+            "default": false
+          },
+          "active": {
+            "description": "Nanoseconds since this peer was last seen",
+            "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
+            "minimum": 0,
+            "type": "integer",
+            "maximum": 9223372036854775807
+          },
+          "offline": {
+            "description": "Indicates the node is considered offline by the group",
+            "type": "boolean",
+            "default": false
+          },
+          "lag": {
+            "description": "How many uncommitted operations this peer is behind the leader",
+            "$comment": "unsigned 64 bit integer",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "peer": {
+            "description": "The unique ID for the peer",
+            "type": "string"
+          },
+          "pending": {
+            "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
+            "type": "boolean",
+            "default": false
+          }
         }
       }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/max_deliver.json
+++ b/schemas/jetstream/advisory/v1/max_deliver.json
@@ -45,6 +45,10 @@
       "type": "integer",
       "minimum": 1,
       "description": "The number of deliveries that were attempted"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/restore_complete.json
+++ b/schemas/jetstream/advisory/v1/restore_complete.json
@@ -146,8 +146,16 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/restore_create.json
+++ b/schemas/jetstream/advisory/v1/restore_create.json
@@ -130,8 +130,16 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/server_out_of_space.json
+++ b/schemas/jetstream/advisory/v1/server_out_of_space.json
@@ -40,6 +40,10 @@
     "cluster": {
       "type": "string",
       "description": "The cluster the server is in"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/snapshot_complete.json
+++ b/schemas/jetstream/advisory/v1/snapshot_complete.json
@@ -140,8 +140,20 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
+    },
+    "error": {
+      "type": "string",
+      "description": "The error that caused the snapshot to fail, when set the snapshot did not complete"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/snapshot_create.json
+++ b/schemas/jetstream/advisory/v1/snapshot_create.json
@@ -142,8 +142,138 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
+    },
+    "state": {
+      "description": "The state of the Stream at the time the snapshot was started",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "messages",
+        "bytes",
+        "first_seq",
+        "last_seq",
+        "consumer_count"
+      ],
+      "properties": {
+        "messages": {
+          "description": "Number of messages stored in the Stream",
+          "minimum": 0,
+          "$comment": "unsigned 64 bit integer",
+          "type": "integer",
+          "maximum": 18446744073709551615
+        },
+        "bytes": {
+          "description": "Combined size of all messages in the Stream",
+          "minimum": 0,
+          "$comment": "unsigned 64 bit integer",
+          "type": "integer",
+          "maximum": 18446744073709551615
+        },
+        "first_seq": {
+          "description": "Sequence number of the first message in the Stream",
+          "minimum": 0,
+          "$comment": "unsigned 64 bit integer",
+          "type": "integer",
+          "maximum": 18446744073709551615
+        },
+        "first_ts": {
+          "description": "The timestamp of the first message in the Stream",
+          "$comment": "A point in time in RFC3339 format including timezone, though typically in UTC",
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_seq": {
+          "description": "Sequence number of the last message in the Stream",
+          "minimum": 0,
+          "$comment": "unsigned 64 bit integer",
+          "type": "integer",
+          "maximum": 18446744073709551615
+        },
+        "last_ts": {
+          "description": "The timestamp of the last message in the Stream",
+          "$comment": "A point in time in RFC3339 format including timezone, though typically in UTC",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deleted": {
+          "description": "IDs of messages that were deleted using the Message Delete API or Interest based streams removing messages out of order",
+          "type": "array",
+          "minLength": 0,
+          "items": {
+            "minimum": 0,
+            "$comment": "unsigned 64 bit integer",
+            "type": "integer",
+            "maximum": 18446744073709551615
+          }
+        },
+        "subjects": {
+          "description": "Subjects and their message counts when a subjects_filter was set",
+          "type": "object",
+          "additionalProperties": {
+            "$comment": "unsigned 64 bit integer",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          }
+        },
+        "num_subjects": {
+          "description": "The number of unique subjects held in the stream",
+          "minimum": 0,
+          "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
+          "type": "integer",
+          "maximum": 9223372036854775807
+        },
+        "num_deleted": {
+          "description": "The number of deleted messages",
+          "minimum": 0,
+          "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
+          "type": "integer",
+          "maximum": 9223372036854775807
+        },
+        "lost": {
+          "type": "object",
+          "description": "Records messages that were damaged and unrecoverable",
+          "properties": {
+            "msgs": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "The messages that were lost",
+              "items": {
+                "minimum": 0,
+                "$comment": "unsigned 64 bit integer",
+                "type": "integer",
+                "maximum": 18446744073709551615
+              }
+            },
+            "bytes": {
+              "description": "The number of bytes that were lost",
+              "$comment": "unsigned 64 bit integer",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 18446744073709551615
+            }
+          }
+        },
+        "consumer_count": {
+          "description": "Number of Consumers attached to the Stream",
+          "minimum": 0,
+          "$comment": "integer with a dynamic bit size depending on the platform the cluster runs on, can be up to 64bit",
+          "type": "integer",
+          "maximum": 9223372036854775807
+        }
+      }
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/snapshot_create.json
+++ b/schemas/jetstream/advisory/v1/snapshot_create.json
@@ -9,9 +9,8 @@
     "id",
     "timestamp",
     "stream",
-    "blocks",
-    "block_size",
-    "client"
+    "client",
+    "state"
   ],
   "additionalProperties": false,
   "properties": {
@@ -30,16 +29,6 @@
     "stream": {
       "type": "string",
       "description": "The name of the Stream being snapshotted"
-    },
-    "blocks": {
-      "type": "integer",
-      "description": "Approximate number of blocks in the snapshot",
-      "minimum": 0
-    },
-    "block_size": {
-      "type": "integer",
-      "description": "The size, in bytes, of every block",
-      "minimum": 1
     },
     "client": {
       "type": "object",

--- a/schemas/jetstream/advisory/v1/stream_action.json
+++ b/schemas/jetstream/advisory/v1/stream_action.json
@@ -41,6 +41,10 @@
     "template": {
       "type": "string",
       "description": "The Stream Template that manages the Stream"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/stream_action.json
+++ b/schemas/jetstream/advisory/v1/stream_action.json
@@ -38,10 +38,6 @@
       "type": "string",
       "description": "The name of the Stream that's acted on"
     },
-    "template": {
-      "type": "string",
-      "description": "The Stream Template that manages the Stream"
-    },
     "domain": {
       "type": "string",
       "description": "The domain of the JetStream server the event is from"

--- a/schemas/jetstream/advisory/v1/stream_leader_elected.json
+++ b/schemas/jetstream/advisory/v1/stream_leader_elected.json
@@ -35,52 +35,63 @@
       "description": "The server name of the elected leader"
     },
     "replicas": {
-      "type": "object",
-      "required": [
-        "name",
-        "current",
-        "active"
-      ],
-      "properties": {
-        "name": {
-          "description": "The server name of the peer",
-          "type": "string",
-          "minLength": 1
-        },
-        "current": {
-          "description": "Indicates if the server is up to date and synchronised",
-          "type": "boolean",
-          "default": false
-        },
-        "active": {
-          "description": "Nanoseconds since this peer was last seen",
-          "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
-          "minimum": 0,
-          "type": "integer",
-          "maximum": 9223372036854775807
-        },
-        "offline": {
-          "description": "Indicates the node is considered offline by the group",
-          "type": "boolean",
-          "default": false
-        },
-        "lag": {
-          "description": "How many uncommitted operations this peer is behind the leader",
-          "$comment": "unsigned 64 bit integer",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615
-        },
-        "peer": {
-          "description": "The unique ID for the peer",
-          "type": "string"
-        },
-        "pending": {
-          "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
-          "type": "boolean",
-          "default": false
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "current",
+          "active"
+        ],
+        "properties": {
+          "name": {
+            "description": "The server name of the peer",
+            "type": "string",
+            "minLength": 1
+          },
+          "current": {
+            "description": "Indicates if the server is up to date and synchronised",
+            "type": "boolean",
+            "default": false
+          },
+          "active": {
+            "description": "Nanoseconds since this peer was last seen",
+            "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
+            "minimum": 0,
+            "type": "integer",
+            "maximum": 9223372036854775807
+          },
+          "offline": {
+            "description": "Indicates the node is considered offline by the group",
+            "type": "boolean",
+            "default": false
+          },
+          "lag": {
+            "description": "How many uncommitted operations this peer is behind the leader",
+            "$comment": "unsigned 64 bit integer",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "peer": {
+            "description": "The unique ID for the peer",
+            "type": "string"
+          },
+          "pending": {
+            "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
+            "type": "boolean",
+            "default": false
+          }
         }
       }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/advisory/v1/stream_quorum_lost.json
+++ b/schemas/jetstream/advisory/v1/stream_quorum_lost.json
@@ -30,52 +30,63 @@
       "description": "The name of the Stream that lost quorum"
     },
     "replicas": {
-      "type": "object",
-      "required": [
-        "name",
-        "current",
-        "active"
-      ],
-      "properties": {
-        "name": {
-          "description": "The server name of the peer",
-          "type": "string",
-          "minLength": 1
-        },
-        "current": {
-          "description": "Indicates if the server is up to date and synchronised",
-          "type": "boolean",
-          "default": false
-        },
-        "active": {
-          "description": "Nanoseconds since this peer was last seen",
-          "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
-          "minimum": 0,
-          "type": "integer",
-          "maximum": 9223372036854775807
-        },
-        "offline": {
-          "description": "Indicates the node is considered offline by the group",
-          "type": "boolean",
-          "default": false
-        },
-        "lag": {
-          "description": "How many uncommitted operations this peer is behind the leader",
-          "$comment": "unsigned 64 bit integer",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 18446744073709551615
-        },
-        "peer": {
-          "description": "The unique ID for the peer",
-          "type": "string"
-        },
-        "pending": {
-          "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
-          "type": "boolean",
-          "default": false
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "current",
+          "active"
+        ],
+        "properties": {
+          "name": {
+            "description": "The server name of the peer",
+            "type": "string",
+            "minLength": 1
+          },
+          "current": {
+            "description": "Indicates if the server is up to date and synchronised",
+            "type": "boolean",
+            "default": false
+          },
+          "active": {
+            "description": "Nanoseconds since this peer was last seen",
+            "$comment": "nanoseconds depicting a duration in time, signed 64 bit integer",
+            "minimum": 0,
+            "type": "integer",
+            "maximum": 9223372036854775807
+          },
+          "offline": {
+            "description": "Indicates the node is considered offline by the group",
+            "type": "boolean",
+            "default": false
+          },
+          "lag": {
+            "description": "How many uncommitted operations this peer is behind the leader",
+            "$comment": "unsigned 64 bit integer",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 18446744073709551615
+          },
+          "peer": {
+            "description": "The unique ID for the peer",
+            "type": "string"
+          },
+          "pending": {
+            "description": "Indicates the peer is part of the assignment, but is not a peer of the Raft group yet or is being removed",
+            "type": "boolean",
+            "default": false
+          }
         }
       }
+    },
+    "account": {
+      "type": "string",
+      "description": "The account the event is for"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/jetstream/metric/v1/consumer_ack.json
+++ b/schemas/jetstream/metric/v1/consumer_ack.json
@@ -57,6 +57,10 @@
       "type": "integer",
       "minimum": 1,
       "description": "The number of deliveries that were attempted before being acknowledged"
+    },
+    "domain": {
+      "type": "string",
+      "description": "The domain of the JetStream server the event is from"
     }
   }
 }

--- a/schemas/server/advisory/v1/account_connections.json
+++ b/schemas/server/advisory/v1/account_connections.json
@@ -78,6 +78,13 @@
           "type": "object",
           "description": "The metadata assigned to the server"
         },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags the server has enabled",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
         "seq": {
           "type": "integer",
           "description": "Internal server sequence ID"
@@ -239,6 +246,15 @@
       "type": "integer",
       "description": "The number of slow consumer errors this account encountered",
       "minimum": 0
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the account"
+    },
+    "num_subscriptions": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The number of subscriptions the account has"
     }
   }
 }

--- a/schemas/server/advisory/v1/client_connect.json
+++ b/schemas/server/advisory/v1/client_connect.json
@@ -75,6 +75,13 @@
           "type": "object",
           "description": "The metadata assigned to the server"
         },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags the server has enabled",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
         "seq": {
           "type": "integer",
           "description": "Internal server sequence ID"
@@ -193,6 +200,10 @@
         },
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
+          "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
           "type": "string"
         }
       }

--- a/schemas/server/advisory/v1/client_disconnect.json
+++ b/schemas/server/advisory/v1/client_disconnect.json
@@ -78,6 +78,13 @@
           "type": "object",
           "description": "The metadata assigned to the server"
         },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags the server has enabled",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
         "seq": {
           "type": "integer",
           "description": "Internal server sequence ID"
@@ -196,6 +203,10 @@
         },
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
+          "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
           "type": "string"
         }
       }

--- a/schemas/server/metric/v1/service_latency.json
+++ b/schemas/server/metric/v1/service_latency.json
@@ -129,6 +129,10 @@
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
           "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
+          "type": "string"
         }
       }
     },
@@ -232,6 +236,10 @@
         },
         "nonce": {
           "description": "The NONCE that was presented to the client during initial INFO",
+          "type": "string"
+        },
+        "reply": {
+          "description": "Original reply subject after a service import, only set when needed",
           "type": "string"
         }
       }


### PR DESCRIPTION
Supersedes https://github.com/nats-io/jsm.go/pull/826

Removal of the advisory fields that the server no longer uses added as a separate commit so it can be backed out if needed.